### PR TITLE
Remove deprecreated function get_or_create_user()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ UNRELEASED
   python-ldap documentation on `bytes mode
   <https://www.python-ldap.org/en/latest/bytes_mode.html>`_
 
+- Removed deprecated function ``LDAPBackend.get_or_create_user()``. Use
+  :meth:`~django_auth_ldap.backend.LDAPBackend.get_or_build_user` instead.
+
 
 1.4.0 - 2018-03-22 - Cleanup and fixes
 --------------------------------------

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -221,18 +221,6 @@ class LDAPBackend(object):
         The returned User object may be an unsaved model instance.
 
         """
-        if self.__class__.get_or_create_user != LDAPBackend.get_or_create_user:
-            # Older deprecated method overridden, defer to it instead.
-            warnings.warn(
-                "Method LDAPBacked.get_or_create_user() is deprecated and will "
-                "be removed in a future version. Override "
-                "LDAPBacked.get_or_build_user() instead. "
-                "LDAPBacked.get_or_build_user() does not need to save newly "
-                "built users.",
-                DeprecationWarning,
-            )
-            return self.get_or_create_user(username, ldap_user)
-
         model = self.get_user_model()
 
         if self.settings.USER_QUERY_FIELD:

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -598,9 +598,8 @@ Backend
         passed through
         :meth:`~django_auth_ldap.backend.LDAPBackend.ldap_to_django_username`.
         You can get information about the LDAP user via ``ldap_user.dn`` and
-        ``ldap_user.attrs``. The return value must be the same as
-        :meth:`~django.db.models.query.QuerySet.get_or_create`--an (instance,
-        created) two-tuple--although the instance does not need to be saved yet.
+        ``ldap_user.attrs``. The return value must be an (instance, created)
+        two-tuple. The instance does not need to be saved.
 
         The default implementation looks for the username with a
         case-insensitive query; if it's not found, the model returned by
@@ -611,16 +610,6 @@ Backend
 
         A subclass may override this to associate LDAP users to Django users any
         way it likes.
-
-    .. method:: get_or_create_user(self, username, ldap_user)
-
-        .. warning::
-
-            Deprecated. This is supported for backwards-compatibility, but will
-            be removed in a future version.
-
-        Like :meth:`get_or_build_user`, but always returns a saved model
-        instance. If you're overriding this, please convert to the new method.
 
     .. method:: ldap_to_django_username(username)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -34,7 +34,6 @@ import io
 import logging
 import os
 import pickle
-import warnings
 
 import ldap
 import mock
@@ -1358,32 +1357,6 @@ class LDAPTest(TestCase):
         mock_search.assert_called_once_with(
             'ou=people,o=test', ldap.SCOPE_SUBTREE, '(uid=alice)', ['*', '+']
         )
-
-    def test_get_or_create_user_deprecated(self):
-        class MyBackend(backend.LDAPBackend):
-            def get_or_create_user(self, username, ldap_user):
-                return super(MyBackend, self).get_or_create_user(username, ldap_user)
-
-        self.backend = MyBackend()
-        self._init_settings(USER_DN_TEMPLATE='uid=%(user)s,ou=people,o=test')
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.backend.authenticate(username='alice', password='password')
-        self.assertEqual(len(w), 1)
-        self.assertEqual(w[0].category, DeprecationWarning)
-
-    def test_custom_backend_without_get_or_create_no_warning(self):
-        class MyBackend(backend.LDAPBackend):
-            pass
-
-        self.backend = MyBackend()
-        self._init_settings(USER_DN_TEMPLATE='uid=%(user)s,ou=people,o=test')
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.backend.authenticate(username='alice', password='password')
-        self.assertEqual(len(w), 0)
 
     def test_override_authenticate_access_ldap_user(self):
         class MyBackend(backend.LDAPBackend):


### PR DESCRIPTION
Custom backends should use get_or_build_user() instead.