### PR TITLE
Use django.contib.auth entrypoints for tests

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -33,5 +33,4 @@ AUTH_USER_MODEL = 'auth.User'
 
 AUTHENTICATION_BACKENDS = [
     'django_auth_ldap.backend.LDAPBackend',
-    'django.contrib.auth.backends.ModelBackend',
 ]


### PR DESCRIPTION
Better simulates real usage and verifies behavior closer to production
scenarios. Should catch more edge cases or improper usage of Django
APIs.