### PR TITLE
Skip install to build docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ skip_install = true
 [testenv:docs]
 deps = sphinx
 commands = make -C docs html
+skip_install = true
 whitelist_externals = make
 
 [testenv:coverage]


### PR DESCRIPTION
The package need not be installed to build docs. Should be slightly
faster.