### PR TITLE
Fix #19: Introduced AUTH_LDAP_CACHE_TIMEOUT, overhaul cache settings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+1.6.0 - Unreleased
+------------------
+
+- The :setting:`AUTH_LDAP_CACHE_TIMEOUT` now replaces old
+  `AUTH_LDAP_CACHE_GROUPS` and `AUTH_LDAP_GROUP_CACHE_TIMEOUT`, it also
+  consistently controls caching of user distinguished name (previously was
+  cached by default since version 1.2.14), in addition to groups. Compatibility
+  is provided with the deprecated settings.
+
+
 1.5.0 - 2018-04-18
 ------------------
 

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -53,9 +53,8 @@ and arguments are included for completeness.
     # Use LDAP group membership to calculate group permissions.
     AUTH_LDAP_FIND_GROUP_PERMS = True
 
-    # Cache group memberships for an hour to minimize LDAP traffic
-    AUTH_LDAP_CACHE_GROUPS = True
-    AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600
+    # Cache user's DN and group memberships for an hour to minimize LDAP traffic
+    AUTH_LDAP_CACHE_TIMEOUT = 3600
 
 
     # Keep ModelBackend around for per-user permissions and maybe a local

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -11,7 +11,8 @@ order of impact.
    default behavior is to reload a user's group memberships on every request.
    This is the safest behavior, as any membership change takes effect
    immediately, but it is expensive. If possible, set
-   :setting:`AUTH_LDAP_CACHE_GROUPS` to ``True`` to remove most of this traffic.
+   :setting:`AUTH_LDAP_CACHE_TIMEOUT` to a nonzero number (in seconds) to remove
+   most of this traffic.
 
 #. **Don't access user.ldap_user.***. Except for ``ldap_user.dn``, these
    properties are only cached on a per-request basis. If you can propagate LDAP

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -29,14 +29,12 @@ associate permissions yourself, generally through the admin interface.
 To minimize traffic to the LDAP server,
 :class:`~django_auth_ldap.backend.LDAPBackend` can make use of Django's cache
 framework to keep a copy of a user's LDAP group memberships. To enable this
-feature, set :setting:`AUTH_LDAP_CACHE_GROUPS` to ``True``. You can also set
-:setting:`AUTH_LDAP_GROUP_CACHE_TIMEOUT` to override the timeout of cache
-entries (in seconds).
+feature, set :setting:`AUTH_LDAP_CACHE_TIMEOUT` to a nonzero number, which
+determines the timeout of cache entries (in seconds).
 
 .. code-block:: python
 
-    AUTH_LDAP_CACHE_GROUPS = True
-    AUTH_LDAP_GROUP_CACHE_TIMEOUT = 300
+    AUTH_LDAP_CACHE_TIMEOUT = 300
 
 
 Group Mirroring

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -72,16 +72,23 @@ Default: ``''`` (Empty string)
 The password to use with :setting:`AUTH_LDAP_BIND_DN`.
 
 
-.. setting:: AUTH_LDAP_CACHE_GROUPS
+.. setting:: AUTH_LDAP_CACHE_TIMEOUT
 
-AUTH_LDAP_CACHE_GROUPS
-~~~~~~~~~~~~~~~~~~~~~~
+AUTH_LDAP_CACHE_TIMEOUT
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``False``
+Default: ``0``
 
-If ``True``, LDAP group membership will be cached using Django's cache
-framework. The cache timeout can be customized with
-:setting:`AUTH_LDAP_GROUP_CACHE_TIMEOUT`.
+If this value is nonzero, the value determines (in seconds) the amount of time
+user's group memberships and distinguished name are cached. Value ``0`` (the
+default) disables caching entirely.
+
+.. versionchanged:: 1.6.0
+
+    Previously caching was controlled by the settings `AUTH_LDAP_CACHE_GROUPS`
+    (`True`/`False`) and `AUTH_LDAP_GROUP_CACHE_TIMEOUT` (in seconds). If
+    `AUTH_LDAP_CACHE_TIMEOUT` is unchanged, its value is derievd from these
+    deprecated settings.
 
 
 .. setting:: AUTH_LDAP_CONNECTION_OPTIONS
@@ -135,17 +142,6 @@ A dictionary of options to pass to ``ldap.set_option()``. Keys are
     Due to its global nature, this setting ignores the :doc:`settings prefix
     <multiconfig>`. Regardless of how many backends are installed, this setting
     is referenced once by its default name at the time we load the ldap module.
-
-
-.. setting:: AUTH_LDAP_GROUP_CACHE_TIMEOUT
-
-AUTH_LDAP_GROUP_CACHE_TIMEOUT
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Default: ``None``
-
-If :setting:`AUTH_LDAP_CACHE_GROUPS` is ``True``, this is the cache timeout for
-group memberships. If ``None``, the global cache timeout will be used.
 
 
 .. setting:: AUTH_LDAP_GROUP_SEARCH

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,7 @@ Following is an example configuration, just to whet your appetite::
     AUTH_LDAP_FIND_GROUP_PERMS = True
 
     # Cache group memberships for an hour to minimize LDAP traffic
-    AUTH_LDAP_CACHE_GROUPS = True
-    AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600
+    AUTH_LDAP_CACHE_TIMEOUT = 3600
 
 
     # Keep ModelBackend around for per-user permissions and maybe a local

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1041,7 +1041,7 @@ class LDAPTest(TestCase):
             GROUP_SEARCH=LDAPSearch('ou=groups,o=test', ldap.SCOPE_SUBTREE),
             GROUP_TYPE=MemberDNGroupType(member_attr='member'),
             FIND_GROUP_PERMS=True,
-            CACHE_GROUPS=True
+            CACHE_TIMEOUT=None
         )
         self._init_groups()
 


### PR DESCRIPTION
* One setting AUTH_LDAP_CACHE_TIMEOUT now replaces both
  GROUP_CACHE_TIMEOUT and CACHE_GROUPS.
* Compatibility with old settings is provided (except
  GROUP_CACHE_TIMEOUT now defaults to 1 hour instead of forever)
* Previously user's DN was always cached even when
  AUTH_LDAP_CACHE_GROUPS was False. Now both groups and user's DN are
  consistently determined by one setting.