### PR TITLE
Document another way to add logging

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -15,3 +15,19 @@ messages.
     logger = logging.getLogger('django_auth_ldap')
     logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.DEBUG)
+
+Or if you're using Django's `LOGGING setting`_, you can add an entry to your
+logging config:
+
+.. _LOGGING setting: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-LOGGING
+
+.. code-block:: python
+
+    LOGGING = {
+        'loggers': {
+            'django_auth_ldap': {
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            },
+        },
+    }


### PR DESCRIPTION
As a user of the `LOGGING` setting, it would be nice if there was something I could copy paste from the docs into my project. This is the config I'm currently using locally.

### Design questions

* I typically need `propagate: False` too, but should it be in the main example?
* is `LOGGING` popular enough that this should be the first example?

### Screenshot

From a local Sphinx build:

![screen shot 2018-07-02 at 14 40 14](https://user-images.githubusercontent.com/189908/42183041-fe8a62a6-7e05-11e8-9653-a5ac42a0fd1c.png)
