### PR TITLE
Test using Django 2.1 final release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,9 @@ envlist =
 [testenv]
 commands = python -m django test --settings tests.settings
 deps =
-    django111: Django ~= 1.11.0
-    django20: Django ~= 2.0.0
-    django21: Django>=2.1a1,<2.2
+    django111: Django~=1.11.0
+    django20: Django~=2.0.0
+    django21: Django~=2.1.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     mock >= 2.0.0
 


### PR DESCRIPTION
Django 2.1 was released on August 1, 2018.

https://docs.djangoproject.com/en/2.1/releases/2.1/