### PR TITLE
Restore use of isort for sorting Python imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   include:
     - env: TOXENV=black
     - env: TOXENV=flake8
+    - env: TOXENV=isort
     - env: TOXENV=docs
 
     - python: 2.7

--- a/django_auth_ldap/__init__.py
+++ b/django_auth_ldap/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
 
-
 version = (1, 7, 0)
 version_string = ".".join(map(str, version))

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -48,31 +48,28 @@ Additional classes can be found in the config module next to this one.
 from __future__ import unicode_literals
 
 import copy
-from functools import reduce
 import operator
 import pprint
 import re
 import warnings
-
-import ldap
+from functools import reduce
 
 import django.conf
+import django.dispatch
+import ldap
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
-import django.dispatch
 from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.inspect import func_supports_parameter
-
 from django_auth_ldap.config import (
     ConfigurationWarning,
     LDAPGroupQuery,
     LDAPSearch,
     _LDAPConfig,
 )
-
 
 logger = _LDAPConfig.get_logger()
 

--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -36,7 +36,6 @@ import pprint
 
 import ldap
 import ldap.filter
-
 from django.utils.encoding import force_text
 from django.utils.tree import Node
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("ext"))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,17 @@ exclude =
 ignore =
     E501
     W503
+
+[isort]
+combine_as_imports = True
+force_grid_wrap = 0
+include_trailing_comma = True
+line_length = 88
+multi_line_output = 3
+not_skip = __init__.py
+skip =
+    .git
+    .tox
+    __pycache__
+    build
+    dist

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup
 
 import django_auth_ldap
 
-
 with open("README.rst") as fp:
     readme = fp.read()
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -27,18 +27,17 @@
 from __future__ import unicode_literals
 
 import contextlib
-from copy import deepcopy
 import functools
 import io
 import logging
 import os
 import pickle
 import warnings
+from copy import deepcopy
 
 import ldap
 import mock
 import slapdtest
-
 from django.contrib.auth import authenticate, get_backends
 from django.contrib.auth.models import Group, Permission, User
 from django.core.cache import cache
@@ -46,7 +45,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-
 from django_auth_ldap.backend import LDAPBackend, ldap_error, populate_user
 from django_auth_ldap.config import (
     GroupOfNamesType,

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,12 @@ deps = flake8
 commands = flake8
 skip_install = true
 
+[testenv:isort]
+basepython = python3
+deps = isort
+commands = isort --check-only --diff
+skip_install = true
+
 [testenv:docs]
 basepython = python3
 deps =


### PR DESCRIPTION
When black was introduced in commit
5c02dc2b5e272efd7619dcbcfe335a71c58d5261, isort was removed. It was
removed under the mistaken impression that black would sort imports
making isort redundant. However, that is not the case. Black has a
policy of only applying format changes and never changing the Python
AST. Reordering imports is altering the AST as it effects execution
order. Restore isort to once again apply a consistent, predictable
Python import order. The isort configuration was adopted from the black
README.md.