### PR TITLE
Get user permisions no only group permission

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -176,13 +176,48 @@ class LDAPBackend(object):
 
         return False
 
-    def get_all_permissions(self, user, obj=None):
-        return self.get_group_permissions(user, obj)
+    def _get_user_permissions(self, user_obj):
+        return user_obj.user_permissions.all()
 
-    def get_group_permissions(self, user, obj=None):
+    def _get_permissions(self, user_obj, obj, from_name):
+        """
+        Return the permissions of `user_obj` from `from_name`. `from_name` can
+        be either "group" or "user" to return permissions from
+        `_get_group_permissions` or `_get_user_permissions` respectively.
+        """
+        if not user_obj.is_active or \
+                user_obj.is_anonymous or\
+                obj is not None or\
+                not hasattr(user, "ldap_user"):
+            return set()
+
+        perm_cache_name = '_%s_perm_cache' % from_name
+        if not hasattr(user_obj, perm_cache_name):
+            if user_obj.is_superuser:
+                perms = Permission.objects.all()
+            else:
+                 perms = getattr(self, '_get_%s_permissions' % from_name)(user_obj)
+
+            perms = perms.values_list('content_type__app_label', 'codename').order_by()
+            setattr(user_obj, perm_cache_name, {"%s.%s" % (ct, name) for ct, name in perms})
+        return getattr(user_obj, perm_cache_name)
+
+    def get_user_permissions(self, user_obj, obj=None):
+        """
+        Return a set of permission strings the user `user_obj` has from their
+        `user_permissions`.
+        """
+        return self._get_permissions(user_obj, obj, 'user')
+
+    def get_all_permissions(self, user, obj=None):
         if not hasattr(user, "ldap_user") and self.settings.AUTHORIZE_ALL_USERS:
             _LDAPUser(self, user=user)  # This sets user.ldap_user
+        return {
+            *self.get_group_permissions(user, obj),
+            *self.get_user_permissions(user)
+        }
 
+    def get_group_permissions(self, user, obj=None):
         if hasattr(user, "ldap_user"):
             permissions = user.ldap_user.get_group_permissions()
         else:


### PR DESCRIPTION
I checked that django-auth-ldap don't return users permissions. I'm very upset because your code is very similar of django.auth. that include  users permissions.

