### PR TITLE
Now get user and group permissions, instead only group permissions

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -177,7 +177,10 @@ class LDAPBackend(object):
         return False
 
     def get_all_permissions(self, user, obj=None):
-        return self.get_group_permissions(user, obj)
+        # Black have a problem when uses "|"
+        return set(
+            self.get_user_permissions(user, obj) | self.get_group_permissions(user, obj)
+        )
 
     def get_group_permissions(self, user, obj=None):
         if not hasattr(user, "ldap_user") and self.settings.AUTHORIZE_ALL_USERS:
@@ -189,6 +192,41 @@ class LDAPBackend(object):
             permissions = set()
 
         return permissions
+
+    def get_user_permissions(self, user, obj=None):
+        if not hasattr(user, "ldap_user") and self.settings.AUTHORIZE_ALL_USERS:
+            _LDAPUser(self, user=user)  # This sets user.ldap_user
+
+        if hasattr(user, "ldap_user"):
+            permissions = self._get_permissions(user, obj, "user")
+        else:
+            permissions = set()
+
+        return permissions
+
+    def _get_permissions(self, user_obj, obj, from_name):
+        """
+        Return the permissions of `user_obj` from `from_name`. `from_name` can
+        be either "group" or "user" to return permissions from
+        `_get_group_permissions` or `_get_user_permissions` respectively.
+        """
+        if not user_obj.is_active or user_obj.is_anonymous or obj is not None:
+            return set()
+
+        perm_cache_name = "_%s_perm_cache" % from_name
+        if not hasattr(user_obj, perm_cache_name):
+            if user_obj.is_superuser:
+                perms = Permission.objects.all()
+            else:
+                perms = getattr(self, "_get_%s_permissions" % from_name)(user_obj)
+            perms = perms.values_list("content_type__app_label", "codename").order_by()
+            setattr(
+                user_obj, perm_cache_name, {"%s.%s" % (ct, name) for ct, name in perms}
+            )
+        return getattr(user_obj, perm_cache_name)
+
+    def _get_user_permissions(self, user_obj):
+        return user_obj.user_permissions.all()
 
     #
     # Bonus API: populate the Django user from LDAP without authenticating.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1576,6 +1576,27 @@ class LDAPTest(TestCase):
             cache.get("django_auth_ldap.user_dn.alice"), "uid=alice,ou=people,o=test"
         )
 
+    def test_user_permissions(self):
+        permissions = [
+            Permission.objects.get(codename="add_user"),
+            Permission.objects.get(codename="change_user"),
+        ]
+
+        backend = get_backend()
+        alice = User.objects.create(username="alice")
+        alice = backend.get_user(alice.pk)
+        alice.user_permissions.add(*permissions)
+
+        self.assertEqual(
+            backend.get_user_permissions(alice), {"auth.add_user", "auth.change_user"}
+        )
+        self.assertEqual(backend.get_group_permissions(alice), set([]))
+        self.assertEqual(
+            backend.get_all_permissions(alice), {"auth.add_user", "auth.change_user"}
+        )
+        self.assertIs(backend.has_perm(alice, "auth.add_user"), True)
+        self.assertIs(backend.has_module_perms(alice, "auth"), True)
+
     #
     # Utilities
     #


### PR DESCRIPTION
Currently, when request for permissions of a user only return group permissions. With this pull request will return group and user permissions. 

@jdufresne I'm sorry for previous PR. I'm quite inexperienced.