### PR TITLE
    Reject requests with no username

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -146,6 +146,9 @@ class LDAPBackend(object):
     #
 
     def authenticate(self, request, username=None, password=None, **kwargs):
+        if username is None:
+            return None
+
         if password or self.settings.PERMIT_EMPTY_PASSWORD:
             ldap_user = _LDAPUser(self, username=username.strip(), request=request)
             user = self.authenticate_ldap_user(ldap_user, password)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -262,6 +262,11 @@ class LDAPTest(TestCase):
         user = authenticate(username="invalid", password="i_do_not_exist")
         self.assertIsNone(user)
 
+    def test_username_none(self):
+        self._init_settings()
+        user = authenticate(username=None, password="password")
+        self.assertIsNone(user)
+
     @spy_ldap("simple_bind_s")
     def test_simple_bind_escaped(self, mock):
         """ Bind with a username that requires escaping. """


### PR DESCRIPTION
When a request comes in with no username, an exception is thrown:
```
AttributeError at /
'NoneType' object has no attribute 'strip'
```
A correct ldap user always needs a username,
so we can reject any request that has no username