### PR TITLE
Add Django 2.2a1 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-django21
     - python: 3.5
+      env: TOXENV=py35-django22
+    - python: 3.6
+      env: TOXENV=py36-django22
+    - python: 3.7
+      env: TOXENV=py37-django22
+    - python: 3.5
       env: TOXENV=py35-djangomaster
     - python: 3.6
       env: TOXENV=py36-djangomaster

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: BSD License",

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py{27,34,35,36}-django111
     py{34,35,36,37}-django20
     py{35,36,37}-django21
+    py{35,36,37}-django22
     py{35,36,37}-djangomaster
 
 [testenv]
@@ -15,6 +16,7 @@ deps =
     django111: Django~=1.11.0
     django20: Django~=2.0.0
     django21: Django~=2.1.0
+    django22: Django>=2.2a1<2.3
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     mock >= 2.0.0
 


### PR DESCRIPTION
Django 2.2 alpha 1 was released on January 17, 2019.

https://www.djangoproject.com/weblog/2019/jan/17/django-22-alpha-1/