### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-license_file = LICENSE
-
 [flake8]
 # E501: line too long
 # W503: line break before binary operator


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is
deprecated.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include LICENSE, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file