### PR TITLE
Update supported Python versions in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,8 +13,8 @@ groups, and permissions.
 * Tests: http://travis-ci.org/django-auth-ldap/django-auth-ldap
 * License: BSD 2-Clause
 
-This version is supported on Python 2.7 and 3.4+; and Django 1.11+. It requires
-`python-ldap`_ >= 3.0.
+This version is supported on Python 3.5+; and Django 1.11+. It requires
+`python-ldap`_ >= 3.1.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Python 2.7 and 3.4 were dropped in 2.0.0.
Currently `python-ldap` is pinned to `>=3.1` in `setup.py`, so I also updated that.