### PR TITLE
Add a way to construct django username from the _LDAPUser object

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -246,6 +246,9 @@ class LDAPBackend:
     def django_to_ldap_username(self, username):
         return username
 
+    def get_django_username_from_ldap_user(self, ldap_user):
+        return self.ldap_to_django_username(ldap_user._username)
+
 
 class _LDAPUser:
     """
@@ -599,7 +602,7 @@ class _LDAPUser:
         """
         save_user = False
 
-        username = self.backend.ldap_to_django_username(self._username)
+        username = self.backend.get_django_username_from_ldap_user(self)
 
         self._user, built = self.backend.get_or_build_user(username, self)
         self._user.ldap_user = self

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -405,6 +405,17 @@ class LDAPTest(TestCase):
         self.assertEqual(user2.ldap_user._username, "alice")
         self.assertEqual(user2.ldap_username, "alice")
 
+        class MyBackend2(LDAPBackend):
+            def get_django_username_from_ldap_user(self, ldap_user):
+                return "ldap_%s" % ldap_user.attrs["sn"][0]
+
+        backend = MyBackend2()
+        user = backend.authenticate(None, username="alice", password="password")
+
+        self.assertEqual(user.username, "ldap_adams")
+        self.assertEqual(user1.ldap_user._username, "alice")
+        self.assertEqual(user1.ldap_username, "alice")
+
     def test_search_bind(self):
         self._init_settings(
             USER_SEARCH=LDAPSearch(


### PR DESCRIPTION
This doesn't include updating the docs - but I'll add that after review of the code, once the final form of how this functionality should be structured is known.

This is a backward compatible change to supercede the
ldap_to_django_username hook with get_django_username_from_ldap_user
which takes _LDAPUser instance as argument and returns the django
username.
By default it just calls ldap_to_django_username(ldap_user._username) to
be compatible with code that's based on older versions of this library
and expects ldap_to_django_username to be the function translating from
ldap username to django.
New code can now in their LDAPBackend subclasses override
get_django_username_from_ldap_user with potentially more sophisticated
logic that constructs the django username from information available
in the _LDAPUser object - typically from the attributes.