### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache: pip
 
@@ -11,15 +10,10 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - python: 3.7
-      env: TOXENV=black
-    - python: 3.7
-      env: TOXENV=flake8
-    - python: 3.7
-      env: TOXENV=isort
-    - python: 3.7
-      env: TOXENV=docs
-
+    - env: TOXENV=black
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
+    - env: TOXENV=docs
     - python: 3.5
       env: TOXENV=py35-django111
     - python: 3.6
@@ -42,7 +36,6 @@ matrix:
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
-
   allow_failures:
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster


### PR DESCRIPTION
- 'dist: xenial' is the default.
- Python 3 is now the default.