### PR TITLE
Remove unnecessary coding cookie

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2009, Peter Sagerson
 # All rights reserved.
 #


### PR DESCRIPTION
Python 3 defaults to utf-8.