### PR TITLE
Added an example to :setting:`AUTH_LDAP_USER_QUERY_FIELD` for clarity.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -279,7 +279,10 @@ Default: ``None``
 The field on the user model used to query the authenticating user in the
 database. If unset, uses the value of ``USERNAME_FIELD`` of the model class.
 When set, the value used to query is obtained through the
-:setting:`AUTH_LDAP_USER_ATTR_MAP`.
+:setting:`AUTH_LDAP_USER_ATTR_MAP`. For example, setting :setting:`AUTH_LDAP_USER_ATTR_MAP`
+to ``username`` and adding ``"username": "sAMAccountName",`` to :setting:`AUTH_LDAP_USER_ATTR_MAP`
+will cause django to query local database using ``username`` column and LDAP using
+``sAMAccountName`` attribute.
 
 
 .. setting:: AUTH_LDAP_USER_ATTRLIST


### PR DESCRIPTION
Expanded reference documentation of `AUTH_LDAP_USER_QUERY_FIELD` with an example of how to use `AUTH_LDAP_USER_QUERY_FIELD` in conjunction with `AUTH_LDAP_USER_ATTR_MAP`.