### PR TITLE
Fixed Typo

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -279,7 +279,10 @@ Default: ``None``
 The field on the user model used to query the authenticating user in the
 database. If unset, uses the value of ``USERNAME_FIELD`` of the model class.
 When set, the value used to query is obtained through the
-:setting:`AUTH_LDAP_USER_ATTR_MAP`.
+:setting:`AUTH_LDAP_USER_ATTR_MAP`. For example, setting :setting:`AUTH_LDAP_USER_ATTR_MAP`
+to ``username`` and adding ``"username": "sAMAccountName",`` to :setting:`AUTH_LDAP_USER_ATTR_MAP`
+will cause django to query local database using ``username`` column and LDAP using
+``sAMAccountName`` attribute.
 
 
 .. setting:: AUTH_LDAP_USER_ATTRLIST

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -279,7 +279,7 @@ Default: ``None``
 The field on the user model used to query the authenticating user in the
 database. If unset, uses the value of ``USERNAME_FIELD`` of the model class.
 When set, the value used to query is obtained through the
-:setting:`AUTH_LDAP_USER_ATTR_MAP`. For example, setting :setting:`AUTH_LDAP_USER_ATTR_MAP`
+:setting:`AUTH_LDAP_USER_ATTR_MAP`. For example, setting :setting:`AUTH_LDAP_USER_QUERY_FIELD`
 to ``username`` and adding ``"username": "sAMAccountName",`` to :setting:`AUTH_LDAP_USER_ATTR_MAP`
 will cause django to query local database using ``username`` column and LDAP using
 ``sAMAccountName`` attribute.


### PR DESCRIPTION
Accidentally mixed up the terms :setting:`AUTH_LDAP_USER_ATTR_MAP` and 
:setting:`AUTH_LDAP_USER_QUERY_FIELD`. Fixed. 