### PR TITLE
BIND_AS_AUTHENTICATING_USER should bind  with the authenticating user also when using the Search/Bind configuration

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -481,7 +481,7 @@ class _LDAPUser:
 
         try:
             if self.settings.BIND_AS_AUTHENTICATING_USER:
-                self._bind_as(self._username, password)
+                self._bind_as(self._username, password, sticky=True)
             else:
                 self._bind_as(self.dn, password)
         except ldap.INVALID_CREDENTIALS:

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -476,13 +476,14 @@ class _LDAPUser:
         Binds to the LDAP server with the user's DN and password. Raises
         AuthenticationFailed on failure.
         """
-        if self.dn is None:
+        if not self.settings.BIND_AS_AUTHENTICATING_USER and self.dn is None:
             raise self.AuthenticationFailed("failed to map the username to a DN.")
 
         try:
-            sticky = self.settings.BIND_AS_AUTHENTICATING_USER
-
-            self._bind_as(self.dn, password, sticky=sticky)
+            if self.settings.BIND_AS_AUTHENTICATING_USER:
+                self._bind_as(self._username, password)
+            else:
+                self._bind_as(self.dn, password)
         except ldap.INVALID_CREDENTIALS:
             raise self.AuthenticationFailed("user DN/password rejected by LDAP server.")
 


### PR DESCRIPTION
I've been struggling with the problem the whole day:
I Was using the following configuration, because I wanted to first bind, using the authenticating user credentials, and then perform an ldap search.

This is the configuration i'm using

```
AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
AUTH_LDAP_USER_SEARCH = LDAPSearch("OU=ex1,OU=example2,OU=ex3,DC=example,DC=ex,DC=com",
                                   ldap.SCOPE_SUBTREE,
                                   "(userprincipalname=%(user)s)")
```
Which caused me the error.

The fix was to actually bind with the authenticating user when `AUTH_LDAP_BIND_AS_AUTHENTICATING_USER`  is set to True and when not using `AUTH_LDAP_USER_DN_TEMPLATE` but instead using `AUTH_LDAP_USER_SEARCH`.

Note that I had to add at line #479 because `self.dn` is not required to be set nor should be read otherwise a binding with `AUTH_LDAP_BIND_DN` and `AUTH_LDAP_BIND_PASSWORD` is done. 