### PR TITLE
change username.lower() to username.strip()

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -229,7 +229,7 @@ class LDAPBackend:
             lookup = query_field
         else:
             query_field = model.USERNAME_FIELD
-            query_value = username.lower()
+            query_value = username.strip()
             lookup = "{}__iexact".format(query_field)
 
         try:


### PR DESCRIPTION
This code causes a `Duplicate entry error` when the username has capitalized