### PR TITLE
Allow using non-default django cache

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -335,10 +335,6 @@ class _LDAPUser:
         user.ldap_user = self
         user.ldap_username = self._username
 
-    @cached_property
-    def cache(self):
-        return caches[getattr(self.settings, "AUTH_LDAP_CACHE", "default")]
-
     @property
     def ldap(self):
         return self.backend.ldap
@@ -892,10 +888,6 @@ class _LDAPUserGroups:
         self._group_names = None
 
         self._init_group_settings()
-
-    @cached_property
-    def cache(self):
-        return caches[getattr(self.settings, "AUTH_LDAP_CACHE", "default")]
 
     def _init_group_settings(self):
         """

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -335,6 +335,10 @@ class _LDAPUser:
         user.ldap_user = self
         user.ldap_username = self._username
 
+    @cached_property
+    def cache(self):
+        return caches[getattr(self.settings, "AUTH_LDAP_CACHE", "default")]
+
     @property
     def ldap(self):
         return self.backend.ldap
@@ -888,6 +892,10 @@ class _LDAPUserGroups:
         self._group_names = None
 
         self._init_group_settings()
+
+    @cached_property
+    def cache(self):
+        return caches[getattr(self.settings, "AUTH_LDAP_CACHE", "default")]
 
     def _init_group_settings(self):
         """

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -117,7 +117,7 @@ class LDAPBackend:
         try:
             return self._cache
         except AttributeError:
-            cache_name = getattr(self.settings, "AUTH_LDAP_CACHE", "default")
+            cache_name = getattr(self.settings, 'AUTH_LDAP_CACHE', 'default')
             self._cache = caches[cache_name]
         return self._cache
 
@@ -368,7 +368,10 @@ class _LDAPUser:
             logger.debug("Authentication failed for {}: {}".format(self._username, e))
         except ldap.LDAPError as e:
             results = ldap_error.send(
-                type(self.backend), context="authenticate", user=self._user, exception=e
+                type(self.backend),
+                context="authenticate",
+                user=self._user,
+                exception=e,
             )
             if len(results) == 0:
                 logger.warning(

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -59,6 +59,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core.cache import caches
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from django.utils.functional import cached_property
 from django.utils.inspect import func_supports_parameter
 
 from django_auth_ldap.config import (
@@ -112,14 +113,9 @@ class LDAPBackend:
             k: v for k, v in self.__dict__.items() if k not in ["_settings", "_ldap"]
         }
 
-    @property
+    @cached_property
     def cache(self):
-        try:
-            return self._cache
-        except AttributeError:
-            cache_name = getattr(self.settings, 'AUTH_LDAP_CACHE', 'default')
-            self._cache = caches[cache_name]
-        return self._cache
+        return caches[getattr(self.settings, "AUTH_LDAP_CACHE", "default")]
 
     @property
     def settings(self):
@@ -371,7 +367,7 @@ class _LDAPUser:
                 type(self.backend),
                 context="authenticate",
                 user=self._user,
-                exception=e,
+                exception=e
             )
             if len(results) == 0:
                 logger.warning(

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -57,7 +57,7 @@ import django.dispatch
 import ldap
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.utils.inspect import func_supports_parameter
 
@@ -111,6 +111,15 @@ class LDAPBackend:
         return {
             k: v for k, v in self.__dict__.items() if k not in ["_settings", "_ldap"]
         }
+
+    @property
+    def cache(self):
+        try:
+            return self._cache
+        except AttributeError:
+            cache_name = getattr(self.settings, "AUTH_LDAP_CACHE", "default")
+            self._cache = caches[cache_name]
+        return self._cache
 
     @property
     def settings(self):
@@ -359,10 +368,7 @@ class _LDAPUser:
             logger.debug("Authentication failed for {}: {}".format(self._username, e))
         except ldap.LDAPError as e:
             results = ldap_error.send(
-                type(self.backend),
-                context="authenticate",
-                user=self._user,
-                exception=e,
+                type(self.backend), context="authenticate", user=self._user, exception=e
             )
             if len(results) == 0:
                 logger.warning(
@@ -514,7 +520,7 @@ class _LDAPUser:
                 cache_key = valid_cache_key(
                     "django_auth_ldap.user_dn.{}".format(self._username)
                 )
-                self._user_dn = cache.get_or_set(
+                self._user_dn = self.cache.get_or_set(
                     cache_key, self._search_for_user_dn, self.settings.CACHE_TIMEOUT
                 )
             else:
@@ -971,14 +977,14 @@ class _LDAPUserGroups:
     def _load_cached_attr(self, attr_name):
         if self.settings.CACHE_TIMEOUT > 0:
             key = self._cache_key(attr_name)
-            value = cache.get(key)
+            value = self.cache.get(key)
             setattr(self, attr_name, value)
 
     def _cache_attr(self, attr_name):
         if self.settings.CACHE_TIMEOUT > 0:
             key = self._cache_key(attr_name)
             value = getattr(self, attr_name, None)
-            cache.set(key, value, self.settings.CACHE_TIMEOUT)
+            self.cache.set(key, value, self.settings.CACHE_TIMEOUT)
 
     def _cache_key(self, attr_name):
         """

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -341,19 +341,6 @@ Values may be strings for simple group membership tests or
 cases.
 
 
-.. setting:: AUTH_LDAP_USER_SEARCH
-
-AUTH_LDAP_USER_SEARCH
-~~~~~~~~~~~~~~~~~~~~~
-
-Default: ``None``
-
-An :class:`~django_auth_ldap.config.LDAPSearch` object that will locate a user
-in the directory. The filter parameter should contain the placeholder
-``%(user)s`` for the username. It must return exactly one result for
-authentication to succeed.
-
-
 .. setting:: AUTH_LDAP_CACHE
 
 AUTH_LDAP_CACHE
@@ -379,6 +366,19 @@ should match a name in the Django cache settings.
         },
     }
     AUTH_LDAP_CACHE = 'ldap-cache'
+
+
+.. setting:: AUTH_LDAP_USER_SEARCH
+
+AUTH_LDAP_USER_SEARCH
+~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``None``
+
+An :class:`~django_auth_ldap.config.LDAPSearch` object that will locate a user
+in the directory. The filter parameter should contain the placeholder
+``%(user)s`` for the username. It must return exactly one result for
+authentication to succeed.
 
 
 Module Properties

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -370,10 +370,6 @@ match a name in the Django cache settings.
 
     CACHES = {
         'default': {
-            'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
-            'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/2'
-        },
-        'celery': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/1'
         },

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -354,6 +354,37 @@ in the directory. The filter parameter should contain the placeholder
 authentication to succeed.
 
 
+.. setting:: AUTH_LDAP_CACHE
+
+AUTH_LDAP_CACHE
+~~~~~~~~~~~~~~~
+
+Default: ``default``
+
+The Django cache framework can store and manage multiple caches, each with
+their own unique name. By default the default cache is used. Setting this value
+tells django-auth-ldap to use a different cache than the default. It should
+match a name in the Django cache settings.
+
+.. code-block:: python
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+            'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/2'
+        },
+        'celery': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/1'
+        },
+        'ldap-cache': {
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'LOCATION': 'unix:/tmp/memcached.sock',
+        },
+    }
+    AUTH_LDAP_CACHE = 'ldap-cache'
+
+
 Module Properties
 -----------------
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,16 +6,3 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTHENTICATION_BACKENDS = ["django_auth_ldap.backend.LDAPBackend"]
-
-AUTH_LDAP_CACHE = 'default'
-
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'unique-snowflake',
-    },
-    'ldap': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'django-auth-ldap',
-    }
-}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,3 +6,16 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTHENTICATION_BACKENDS = ["django_auth_ldap.backend.LDAPBackend"]
+
+AUTH_LDAP_CACHE = 'default'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'unique-snowflake',
+    },
+    'ldap': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'django-auth-ldap',
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -35,7 +35,7 @@ import ldap
 import slapdtest
 from django.contrib.auth import authenticate, get_backends
 from django.contrib.auth.models import Group, Permission, User
-from django.core.cache import caches
+from django.core.cache import cache, caches
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -150,8 +150,8 @@ class LDAPTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        for cache in caches.values():
-            cache.clear()
+        for c in caches.all():
+            c.clear()
 
     def test_options(self):
         self._init_settings(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -35,7 +35,7 @@ import ldap
 import slapdtest
 from django.contrib.auth import authenticate, get_backends
 from django.contrib.auth.models import Group, Permission, User
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -150,7 +150,8 @@ class LDAPTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        cache.clear()
+        for cache in caches.values():
+            cache.clear()
 
     def test_options(self):
         self._init_settings(


### PR DESCRIPTION
It is handy to be able to flush the ldap cache without flushing the entire default django cache. That can reset non-token based logins and all kinds of data you may or may not want. Being able to configure it to use it's own independent cache within the Django caching framework is reallllly handy! 