### PR TITLE
Remove dependency on mock

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 black
 Django >= 2.2
 flake8
-mock >= 2.0.0
 python-ldap >= 3.0
 sphinx

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,9 +29,9 @@ import os
 import pickle
 import warnings
 from copy import deepcopy
+from unittest import mock
 
 import ldap
-import mock
 import slapdtest
 from django.contrib.auth import authenticate, get_backends
 from django.contrib.auth.models import Group, Permission, User

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     django30: Django>=3.0<3.1
     django31: Django>=3.1<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
-    mock >= 2.0.0
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
Mock is shipped with unittest from Python 3.3 onwards.