### PR TITLE
Add Django 3.1 to trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Intended Audience :: Developers
     Intended Audience :: System Administrators
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
Missed in 94ed6e6d97e913e595f6838a347a119ba24aa782.