### PR TITLE
Use setuptools_scm for packaging

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,15 @@ jobs:
       TOXENV: docs
 
     steps:
+      - name: Install LDAP libs
+        run: |
+          sudo apt-get update
+          # https://www.python-ldap.org/en/latest/installing.html#debian
+          sudo apt-get install slapd ldap-utils libldap2-dev libsasl2-dev
+          # https://github.com/python-ldap/python-ldap/issues/370
+          sudo apt-get install apparmor-utils
+          sudo aa-disable /usr/sbin/slapd
+
       - uses: actions/checkout@v2
 
       - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ build/
 dist/
 MANIFEST
 
+# Written by setuptools_scm.
+django_auth_ldap/version.py
+
 .coverage
 .tox/

--- a/django_auth_ldap/__init__.py
+++ b/django_auth_ldap/__init__.py
@@ -1,2 +1,6 @@
-VERSION = (2, 2, 0)
-__version__ = ".".join(str(i) for i in VERSION)
+try:
+    from .version import version
+except ImportError:
+    __version__ = None
+else:
+    __version__ = version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 import os
 import sys
 
+from pkg_resources import get_distribution
+
 sys.path.insert(0, os.path.abspath("ext"))
 
 
@@ -22,10 +24,8 @@ project = "django-auth-ldap"
 copyright = "2009, Peter Sagerson"
 author = "Peter Sagerson"
 
-# The short X.Y version
-version = "2.2"
-# The full version, including alpha/beta/rc tags
-release = "2.2.0"
+release = get_distribution("django-auth-ldap").version
+version = ".".join(release.split(".")[:2])
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=3.4",
+]
+
+[tool.setuptools_scm]
+write_to = "django_auth_ldap/version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = django-auth-ldap
-version = attr: django_auth_ldap.__version__
 description = Django LDAP authentication backend.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ deps =
     sphinx
 commands =
     make -C docs html
-skip_install = true
 whitelist_externals = make
 
 [testenv:packaging]


### PR DESCRIPTION
Follow recommendation from https://jazzband.co/about/releases#packaging.

The documentation now derives its version from the packaged release.
Follow https://github.com/pypa/setuptools_scm/#usage-from-sphinx and
read the version with setuptools.