### PR TITLE
Drop Python versions from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist =
     flake8
     isort
     docs
-    py{36,37,38}-django22
-    py{36,37,38}-django30
-    py{36,37,38}-django31
-    py{36,37,38}-djangomaster
+    django22
+    django30
+    django31
+    djangomaster
 
 [testenv]
 commands = {envpython} -Wa -b -m django test --settings tests.settings


### PR DESCRIPTION
The github actions are the source of truth for Python versions.