### PR TITLE
Use twine to check packaging markup

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,34 @@
+name: Packaging
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Packaging
+    runs-on: ubuntu-latest
+
+    env:
+      TOXENV: packaging
+
+    steps:
+      - name: Install LDAP libs
+        run: |
+          sudo apt-get update
+          # https://www.python-ldap.org/en/latest/installing.html#debian
+          sudo apt-get install slapd ldap-utils libldap2-dev libsasl2-dev
+          # https://github.com/python-ldap/python-ldap/issues/370
+          sudo apt-get install apparmor-utils
+          sudo aa-disable /usr/sbin/slapd
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: python -m pip install tox
+
+      - name: Run tests
+        run: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = django-auth-ldap
 version = attr: django_auth_ldap.__version__
 description = Django LDAP authentication backend.
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = Peter Sagerson
 author_email = psagers@ignorare.net
 url = https://github.com/django-auth-ldap/django-auth-ldap

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,13 @@ deps =
     sphinx
 commands =
     make -C docs html
-    {envpython} setup.py check --restructuredtext --strict
 skip_install = true
 whitelist_externals = make
+
+[testenv:packaging]
+deps =
+    twine
+skip_install = true
+commands =
+    python setup.py sdist
+    twine check dist/*


### PR DESCRIPTION
The setup.py check command is deprecated, use twine.
https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup.

Split out the packaging test from the documentation test. Twine verifies
multiple aspects of the sdist, not just the documentation.