### PR TITLE
Remove basepython directive from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,25 +18,21 @@ deps =
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:black]
-basepython = python3
 deps = black
 commands = black --check --diff .
 skip_install = true
 
 [testenv:flake8]
-basepython = python3
 deps = flake8
 commands = flake8
 skip_install = true
 
 [testenv:isort]
-basepython = python3
 deps = isort>=5.0.1
 commands = isort --check --diff .
 skip_install = true
 
 [testenv:docs]
-basepython = python3
 deps =
     readme_renderer
     sphinx


### PR DESCRIPTION
Python 3 is the only supported version of Python.