### PR TITLE
Remove dev-requirements.txt

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ UNRELEASED
 - Removed support for end of life Python 3.5.
 - Added support for Django 3.1.
 - Added support for Python 3.9.
+- Removed ``dev-requirements.txt`` in favor of :doc:`tox <tox:index>`.
 
 2.2.0 - 2020-06-02
 ------------------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,0 @@
-black
-Django >= 2.2
-flake8
-python-ldap >= 3.0
-sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,4 +174,5 @@ intersphinx_mapping = {
         "https://docs.djangoproject.com/en/stable/_objects/",
     ),
     "pythonldap": ("https://python-ldap.readthedocs.io/en/latest/", None),
+    "tox": ("https://tox.readthedocs.io/en/latest/", None),
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -18,21 +18,8 @@ anchor point.
 Development
 -----------
 
-To get set up for development, activate your virtualenv and use pip to install
-from ``dev-requirements.txt``:
-
-.. code-block:: sh
-
-    $ pip install -r dev-requirements.txt
-
-To run the tests:
-
-.. code-block:: sh
-
-    $ django-admin test --settings tests.settings
-
-To run the full test suite in a range of environments, run `tox`_ from the root
-of the project:
+To run the full test suite in a range of environments, run :doc:`tox <tox:index>`
+from the root of the project:
 
 .. code-block:: sh
 
@@ -41,4 +28,8 @@ of the project:
 This includes some static analysis to detect potential runtime errors and style
 issues.
 
-.. _`tox`: https://tox.readthedocs.io/
+To limit to a single environment, use :option:`tox.-e`:
+
+.. code-block:: console
+
+   $ tox -e djangomaster


### PR DESCRIPTION
Duplicates information from the setup.cfg and tox.ini.

Tox was added to the documentation as an intersphinx target to
facilitate link maintenance.