### PR TITLE
Fix django version specification in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ envlist =
 commands = {envpython} -Wa -b -m django test --settings tests.settings
 deps =
     django22: Django~=2.2.0
-    django30: Django>=3.0<3.1
-    django31: Django>=3.1<3.2
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:black]


### PR DESCRIPTION
The specified version was invalid, causing tests to default to the
latest version.