### PR TITLE
chore(LDAPUser): change _LDAPUser._normalize_mirror_settings() to no longer edit LDAPSettings

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -51,60 +51,88 @@ import pprint
 import re
 import warnings
 from functools import reduce
+from logging import Logger
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import django.conf
 import django.dispatch
 import ldap
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import AbstractUser, Group, Permission
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from django.http import HttpRequest
 from django.utils.inspect import func_supports_parameter
+from ldap.ldapobject import LDAPObject
 
 from django_auth_ldap.config import (
+    AbstractLDAPSearch,
     ConfigurationWarning,
     LDAPGroupQuery,
+    LDAPGroupType,
     LDAPSearch,
     _LDAPConfig,
 )
 
-logger = _LDAPConfig.get_logger()
+# TODO remove try/catch when dropping support for Django 2.2
+try:
+    from django.contrib.auth.backends import BaseBackend
+except ImportError:
+    # BaseBackend was first introduced to Django in version 3.0,
+    # thus to support Django 2.2 the ImportError must be caught.
+    BaseBackend = object
 
+T = TypeVar("T")
+
+logger: Logger = _LDAPConfig.get_logger()
 
 # Exported signals
 
 # Allows clients to perform custom user population.
 # Passed arguments: user, ldap_user
-populate_user = django.dispatch.Signal()
+populate_user: django.dispatch.Signal = django.dispatch.Signal()
 
 # Allows clients to inspect and perform special handling of LDAPError
 # exceptions. Exceptions raised by handlers will be propagated out.
 # Passed arguments: context, user, exception
-ldap_error = django.dispatch.Signal()
+ldap_error: django.dispatch.Signal = django.dispatch.Signal()
 
 
-class LDAPBackend:
+class LDAPBackend(BaseBackend):
     """
     The main backend class. This implements the auth backend API, although it
     actually delegates most of its work to _LDAPUser, which is defined next.
     """
 
-    supports_anonymous_user = False
-    supports_object_permissions = True
-    supports_inactive_user = False
+    supports_anonymous_user: bool = False
+    supports_object_permissions: bool = True
+    supports_inactive_user: bool = False
 
-    _settings = None
-    _ldap = None  # The cached ldap module (or mock object)
+    _settings: Optional["LDAPSettings"] = None
+    _ldap: ldap = None  # The cached ldap module (or mock object)
 
     # This is prepended to our internal setting names to produce the names we
     # expect in Django's settings file. Subclasses can change this in order to
     # support multiple collections of settings.
-    settings_prefix = "AUTH_LDAP_"
+    settings_prefix: str = "AUTH_LDAP_"
 
     # Default settings to override the built-in defaults.
-    default_settings = {}
+    default_settings: Dict[str, Any] = dict()
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         """
         Exclude certain cached properties from pickling.
         """
@@ -113,18 +141,18 @@ class LDAPBackend:
         }
 
     @property
-    def settings(self):
+    def settings(self) -> "LDAPSettings":
         if self._settings is None:
             self._settings = LDAPSettings(self.settings_prefix, self.default_settings)
 
         return self._settings
 
     @settings.setter
-    def settings(self, settings):
+    def settings(self, settings: "LDAPSettings") -> None:
         self._settings = settings
 
     @property
-    def ldap(self):
+    def ldap(self) -> ldap:
         if self._ldap is None:
             options = getattr(django.conf.settings, "AUTH_LDAP_GLOBAL_OPTIONS", None)
 
@@ -132,7 +160,7 @@ class LDAPBackend:
 
         return self._ldap
 
-    def get_user_model(self):
+    def get_user_model(self) -> Type[AbstractUser]:
         """
         By default, this will return the model class configured by
         AUTH_USER_MODEL. Subclasses may wish to override it and return a proxy
@@ -144,7 +172,13 @@ class LDAPBackend:
     # The Django auth backend API
     #
 
-    def authenticate(self, request, username=None, password=None, **kwargs):
+    def authenticate(
+        self,
+        request: Optional[HttpRequest],
+        username: Optional[str] = None,
+        password: str = "",
+        **kwargs: Any
+    ) -> Optional[AbstractUser]:
         if username is None:
             return None
 
@@ -157,7 +191,7 @@ class LDAPBackend:
 
         return user
 
-    def get_user(self, user_id):
+    def get_user(self, user_id: Any) -> Optional[AbstractUser]:
         user = None
 
         try:
@@ -168,20 +202,26 @@ class LDAPBackend:
 
         return user
 
-    def has_perm(self, user, perm, obj=None):
+    def has_perm(
+        self, user: AbstractUser, perm: str, obj: Optional[Any] = None
+    ) -> bool:
         return perm in self.get_all_permissions(user, obj)
 
-    def has_module_perms(self, user, app_label):
+    def has_module_perms(self, user: AbstractUser, app_label: str) -> bool:
         for perm in self.get_all_permissions(user):
             if perm[: perm.index(".")] == app_label:
                 return True
 
         return False
 
-    def get_all_permissions(self, user, obj=None):
+    def get_all_permissions(
+        self, user: AbstractUser, obj: Optional[Any] = None
+    ) -> Set[str]:
         return self.get_group_permissions(user, obj)
 
-    def get_group_permissions(self, user, obj=None):
+    def get_group_permissions(
+        self, user: AbstractUser, obj: Optional[Any] = None
+    ) -> Set[str]:
         if not hasattr(user, "ldap_user") and self.settings.AUTHORIZE_ALL_USERS:
             _LDAPUser(self, user=user)  # This sets user.ldap_user
 
@@ -196,7 +236,7 @@ class LDAPBackend:
     # Bonus API: populate the Django user from LDAP without authenticating.
     #
 
-    def populate_user(self, username):
+    def populate_user(self, username: str) -> Optional[AbstractUser]:
         ldap_user = _LDAPUser(self, username=username)
         return ldap_user.populate_user()
 
@@ -204,13 +244,17 @@ class LDAPBackend:
     # Hooks for subclasses
     #
 
-    def authenticate_ldap_user(self, ldap_user, password):
+    def authenticate_ldap_user(
+        self, ldap_user: "_LDAPUser", password: str
+    ) -> Optional[AbstractUser]:
         """
         Returns an authenticated Django user or None.
         """
         return ldap_user.authenticate(password)
 
-    def get_or_build_user(self, username, ldap_user):
+    def get_or_build_user(
+        self, username: str, ldap_user: "_LDAPUser"
+    ) -> Tuple[AbstractUser, bool]:
         """
         This must return a (User, built) 2-tuple for the given LDAP user.
 
@@ -224,6 +268,9 @@ class LDAPBackend:
         model = self.get_user_model()
 
         if self.settings.USER_QUERY_FIELD:
+            if ldap_user.attrs is None:
+                raise TypeError("The attrs of the LDAP user should not be None")
+
             query_field = self.settings.USER_QUERY_FIELD
             query_value = ldap_user.attrs[self.settings.USER_ATTR_MAP[query_field]][0]
             lookup = query_field
@@ -240,12 +287,12 @@ class LDAPBackend:
         else:
             built = False
 
-        return (user, built)
+        return user, built
 
-    def ldap_to_django_username(self, username):
+    def ldap_to_django_username(self, username: str) -> str:
         return username
 
-    def django_to_ldap_username(self, username):
+    def django_to_ldap_username(self, username: str) -> str:
         return username
 
 
@@ -266,27 +313,33 @@ class _LDAPUser:
         pass
 
     # Defaults
-    _user = None
-    _user_dn = None
-    _user_attrs = None
-    _groups = None
-    _group_permissions = None
-    _connection = None
-    _connection_bound = False
+    _user: Optional[AbstractUser] = None
+    _user_dn: Optional[str] = None
+    _user_attrs: Optional[Dict[str, List[str]]] = None
+    _groups: Optional["_LDAPUserGroups"] = None
+    _group_permissions: Optional[Set[str]] = None
+    _connection: Optional[LDAPObject] = None
+    _connection_bound: bool = False
 
     #
     # Initialization
     #
 
-    def __init__(self, backend, username=None, user=None, request=None):
+    def __init__(
+        self,
+        backend: LDAPBackend,
+        username: Optional[str] = None,
+        user: Optional[AbstractUser] = None,
+        request: Optional[HttpRequest] = None,
+    ) -> None:
         """
         A new LDAPUser must be initialized with either a username or an
         authenticated User object. If a user is given, the username will be
         ignored.
         """
-        self.backend = backend
-        self._username = username
-        self._request = request
+        self.backend: LDAPBackend = backend
+        self._username: Optional[str] = username
+        self._request: Optional[HttpRequest] = request
 
         if user is not None:
             self._set_authenticated_user(user)
@@ -294,7 +347,7 @@ class _LDAPUser:
         if username is None and user is None:
             raise Exception("Internal error: _LDAPUser improperly initialized.")
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict) -> "_LDAPUser":
         obj = object.__new__(type(self))
         obj.backend = self.backend
         obj._user = copy.deepcopy(self._user, memo)
@@ -312,7 +365,7 @@ class _LDAPUser:
 
         return obj
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         """
         Most of our properties are cached from the LDAP server. We only want to
         pickle a few crucial things.
@@ -323,7 +376,7 @@ class _LDAPUser:
             if k in ["backend", "_username", "_user"]
         }
 
-    def _set_authenticated_user(self, user):
+    def _set_authenticated_user(self, user: AbstractUser) -> None:
         self._user = user
         self._username = self.backend.django_to_ldap_username(user.get_username())
 
@@ -331,18 +384,18 @@ class _LDAPUser:
         user.ldap_username = self._username
 
     @property
-    def ldap(self):
+    def ldap(self) -> ldap:
         return self.backend.ldap
 
     @property
-    def settings(self):
+    def settings(self) -> "LDAPSettings":
         return self.backend.settings
 
     #
     # Entry points
     #
 
-    def authenticate(self, password):
+    def authenticate(self, password: str) -> AbstractUser:
         """
         Authenticates against the LDAP directory and returns the corresponding
         User object if successful. Returns None on failure.
@@ -376,7 +429,7 @@ class _LDAPUser:
 
         return user
 
-    def get_group_permissions(self):
+    def get_group_permissions(self) -> Set[str]:
         """
         If allowed by the configuration, this returns the set of permissions
         defined by the user's LDAP group memberships.
@@ -404,7 +457,7 @@ class _LDAPUser:
 
         return self._group_permissions
 
-    def populate_user(self):
+    def populate_user(self) -> AbstractUser:
         """
         Populates the Django user object using the default bind credentials.
         """
@@ -441,29 +494,29 @@ class _LDAPUser:
     #
 
     @property
-    def dn(self):
+    def dn(self) -> Optional[str]:
         if self._user_dn is None:
             self._load_user_dn()
 
         return self._user_dn
 
     @property
-    def attrs(self):
+    def attrs(self) -> Optional[Dict[str, List[str]]]:
         if self._user_attrs is None:
             self._load_user_attrs()
 
         return self._user_attrs
 
     @property
-    def group_dns(self):
+    def group_dns(self) -> Set[str]:
         return self._get_groups().get_group_dns()
 
     @property
-    def group_names(self):
+    def group_names(self) -> Set[str]:
         return self._get_groups().get_group_names()
 
     @property
-    def connection(self):
+    def connection(self) -> LDAPObject:
         if not self._connection_bound:
             self._bind()
 
@@ -473,7 +526,7 @@ class _LDAPUser:
     # Authentication
     #
 
-    def _authenticate_user_dn(self, password):
+    def _authenticate_user_dn(self, password: str) -> None:
         """
         Binds to the LDAP server with the user's DN and password. Raises
         AuthenticationFailed on failure.
@@ -488,25 +541,27 @@ class _LDAPUser:
         except ldap.INVALID_CREDENTIALS:
             raise self.AuthenticationFailed("user DN/password rejected by LDAP server.")
 
-    def _load_user_attrs(self):
+    def _load_user_attrs(self) -> None:
         if self.dn is not None:
             search = LDAPSearch(
                 self.dn, ldap.SCOPE_BASE, attrlist=self.settings.USER_ATTRLIST
             )
             results = search.execute(self.connection)
 
-            if results is not None and len(results) > 0:
-                self._user_attrs = results[0][1]
+            if results is not None:
+                result = next(iter(results), None)
+                if result is not None:
+                    self._user_attrs = result[1]
 
-    def _load_user_dn(self):
+    def _load_user_dn(self) -> None:
         """
         Populates self._user_dn with the distinguished name of our user.
 
         This will either construct the DN from a template in
         AUTH_LDAP_USER_DN_TEMPLATE or connect to the server and search for it.
         If we have to search, we'll cache the DN.
-
         """
+
         if self._using_simple_bind_mode():
             self._user_dn = self._construct_simple_user_dn()
         else:
@@ -520,15 +575,20 @@ class _LDAPUser:
             else:
                 self._user_dn = self._search_for_user_dn()
 
-    def _using_simple_bind_mode(self):
+    def _using_simple_bind_mode(self) -> bool:
         return self.settings.USER_DN_TEMPLATE is not None
 
-    def _construct_simple_user_dn(self):
+    def _construct_simple_user_dn(self) -> str:
+        if self.settings.USER_DN_TEMPLATE is None:
+            raise ImproperlyConfigured(
+                "%s should not be None" % self.settings._name("USER_DN_TEMPLATE")
+            )
+
         template = self.settings.USER_DN_TEMPLATE
         username = ldap.dn.escape_dn_chars(self._username)
         return template % {"user": username}
 
-    def _search_for_user_dn(self):
+    def _search_for_user_dn(self) -> Optional[str]:
         """
         Searches the directory for a user matching AUTH_LDAP_USER_SEARCH.
         Populates self._user_dn and self._user_attrs.
@@ -540,14 +600,13 @@ class _LDAPUser:
             )
 
         results = search.execute(self.connection, {"user": self._username})
+        user_dn = None
         if results is not None and len(results) == 1:
             (user_dn, self._user_attrs) = next(iter(results))
-        else:
-            user_dn = None
 
         return user_dn
 
-    def _check_requirements(self):
+    def _check_requirements(self) -> None:
         """
         Checks all authentication requirements beyond credentials. Raises
         AuthenticationFailed on failure.
@@ -555,7 +614,7 @@ class _LDAPUser:
         self._check_required_group()
         self._check_denied_group()
 
-    def _check_required_group(self):
+    def _check_required_group(self) -> bool:
         """
         Returns True if the group requirement (AUTH_LDAP_REQUIRE_GROUP) is
         met. Always returns True if AUTH_LDAP_REQUIRE_GROUP is None.
@@ -573,7 +632,7 @@ class _LDAPUser:
 
         return True
 
-    def _check_denied_group(self):
+    def _check_denied_group(self) -> bool:
         """
         Returns True if the negative group requirement (AUTH_LDAP_DENY_GROUP)
         is met. Always returns True if AUTH_LDAP_DENY_GROUP is None.
@@ -593,13 +652,16 @@ class _LDAPUser:
     # User management
     #
 
-    def _get_or_create_user(self, force_populate=False):
+    def _get_or_create_user(self, force_populate: bool = False) -> None:
         """
         Loads the User model object from the database or creates it if it
         doesn't exist. Also populates the fields, subject to
         AUTH_LDAP_ALWAYS_UPDATE_USER.
         """
         save_user = False
+
+        if self._username is None:
+            raise TypeError("The username should not be None")
 
         username = self.backend.ldap_to_django_username(self._username)
 
@@ -636,16 +698,19 @@ class _LDAPUser:
             self._normalize_mirror_settings()
             self._mirror_groups()
 
-    def _populate_user(self):
+    def _populate_user(self) -> None:
         """
         Populates our User object with information from the LDAP directory.
         """
         self._populate_user_from_attributes()
         self._populate_user_from_group_memberships()
 
-    def _populate_user_from_attributes(self):
+    def _populate_user_from_attributes(self) -> None:
         for field, attr in self.settings.USER_ATTR_MAP.items():
             try:
+                if self.attrs is None:
+                    raise TypeError("The attrs of the LDAP user should not be None")
+
                 value = self.attrs[attr][0]
             except (TypeError, LookupError):
                 # TypeError occurs when self.attrs is None as we were unable to
@@ -658,7 +723,7 @@ class _LDAPUser:
             else:
                 setattr(self._user, field, value)
 
-    def _populate_user_from_group_memberships(self):
+    def _populate_user_from_group_memberships(self) -> None:
         for field, group_dns in self.settings.USER_FLAGS_BY_GROUP.items():
             try:
                 query = self._normalize_group_dns(group_dns)
@@ -670,15 +735,23 @@ class _LDAPUser:
             value = query.resolve(self)
             setattr(self._user, field, value)
 
-    def _normalize_group_dns(self, group_dns):
+    def _normalize_group_dns(
+        self,
+        group_dns: Union[
+            str,
+            LDAPGroupQuery,
+            List[Union[str, LDAPGroupQuery]],
+            Tuple[Union[str, LDAPGroupQuery]],
+        ],
+    ) -> LDAPGroupQuery:
         """
         Converts one or more group DNs to an LDAPGroupQuery.
 
         group_dns may be a string, a non-empty list or tuple of strings, or an
         LDAPGroupQuery. The result will be an LDAPGroupQuery. A list or tuple
         will be joined with the | operator.
-
         """
+
         if isinstance(group_dns, LDAPGroupQuery):
             query = group_dns
         elif isinstance(group_dns, str):
@@ -690,19 +763,19 @@ class _LDAPUser:
 
         return query
 
-    def _normalize_mirror_settings(self):
+    def _normalize_mirror_settings(self) -> None:
         """
         Validates the group mirroring settings and converts them as necessary.
         """
 
-        def malformed_mirror_groups_except():
+        def malformed_mirror_groups_except() -> ImproperlyConfigured:
             return ImproperlyConfigured(
                 "{} must be a collection of group names".format(
                     self.settings._name("MIRROR_GROUPS_EXCEPT")
                 )
             )
 
-        def malformed_mirror_groups():
+        def malformed_mirror_groups() -> ImproperlyConfigured:
             return ImproperlyConfigured(
                 "{} must be True or a collection of group names".format(
                     self.settings._name("MIRROR_GROUPS")
@@ -746,11 +819,14 @@ class _LDAPUser:
             ):
                 raise malformed_mirror_groups()
 
-    def _mirror_groups(self):
+    def _mirror_groups(self) -> None:
         """
         Mirrors the user's LDAP groups in the Django database and updates the
         user's membership.
         """
+        if self._user is None:
+            raise TypeError("The user should not be None")
+
         target_group_names = frozenset(self._get_groups().get_group_names())
         current_group_names = frozenset(
             self._user.groups.values_list("name", flat=True).iterator()
@@ -790,7 +866,7 @@ class _LDAPUser:
     # Group information
     #
 
-    def _load_group_permissions(self):
+    def _load_group_permissions(self) -> None:
         """
         Populates self._group_permissions based on LDAP group membership and
         Django group permissions.
@@ -803,7 +879,7 @@ class _LDAPUser:
 
         self._group_permissions = {"{}.{}".format(ct, name) for ct, name in perms}
 
-    def _get_groups(self):
+    def _get_groups(self) -> "_LDAPUserGroups":
         """
         Returns an _LDAPUserGroups object, which can determine group
         membership.
@@ -817,14 +893,14 @@ class _LDAPUser:
     # LDAP connection
     #
 
-    def _bind(self):
+    def _bind(self) -> None:
         """
         Binds to the LDAP server with AUTH_LDAP_BIND_DN and
         AUTH_LDAP_BIND_PASSWORD.
         """
         self._bind_as(self.settings.BIND_DN, self.settings.BIND_PASSWORD, sticky=True)
 
-    def _bind_as(self, bind_dn, bind_password, sticky=False):
+    def _bind_as(self, bind_dn: str, bind_password: str, sticky: bool = False) -> None:
         """
         Binds to the LDAP server with the given credentials. This does not trap
         exceptions.
@@ -837,7 +913,7 @@ class _LDAPUser:
 
         self._connection_bound = sticky
 
-    def _get_connection(self):
+    def _get_connection(self) -> LDAPObject:
         """
         Returns our cached LDAPObject, which may or may not be bound.
         """
@@ -854,7 +930,7 @@ class _LDAPUser:
                         "version." % (uri.__module__, uri.__name__),
                         DeprecationWarning,
                     )
-                    uri = uri()
+                    uri = uri()  # type: ignore
 
             self._connection = self.backend.ldap.initialize(uri, bytes_mode=False)
 
@@ -873,24 +949,24 @@ class _LDAPUserGroups:
     Represents the set of groups that a user belongs to.
     """
 
-    def __init__(self, ldap_user):
-        self.settings = ldap_user.settings
-        self._ldap_user = ldap_user
-        self._group_type = None
-        self._group_search = None
-        self._group_infos = None
-        self._group_dns = None
-        self._group_names = None
+    def __init__(self, ldap_user: _LDAPUser) -> None:
+        self.settings: LDAPSettings = ldap_user.settings
+        self._ldap_user: _LDAPUser = ldap_user
+        self._group_type: Optional[LDAPGroupType] = None
+        self._group_search: Optional[AbstractLDAPSearch] = None
+        self._group_infos: Optional[Collection[Tuple[str, Dict[str, List[str]]]]] = None
+        self._group_dns: Optional[Set[str]] = None
+        self._group_names: Optional[Set[str]] = None
 
         self._init_group_settings()
 
-    def _init_group_settings(self):
+    def _init_group_settings(self) -> None:
         """
         Loads the settings we need to deal with groups.
 
         Raises ImproperlyConfigured if anything's not right.
-
         """
+
         self._group_type = self.settings.GROUP_TYPE
         if self._group_type is None:
             raise ImproperlyConfigured(
@@ -903,7 +979,7 @@ class _LDAPUserGroups:
                 "AUTH_LDAP_GROUP_SEARCH must be an LDAPSearch instance."
             )
 
-    def get_group_names(self):
+    def get_group_names(self) -> Set[str]:
         """
         Returns the set of Django group names that this user belongs to by
         virtue of LDAP group memberships.
@@ -912,16 +988,22 @@ class _LDAPUserGroups:
             self._load_cached_attr("_group_names")
 
         if self._group_names is None:
+            if self._group_type is None:
+                raise TypeError("The group type should not be None")
+
             group_infos = self._get_group_infos()
-            self._group_names = {
+            group_names = {
                 self._group_type.group_name_from_info(group_info)
                 for group_info in group_infos
             }
+            if None in group_names:
+                group_names.remove(None)
+            self._group_names = cast(Set[str], group_names)
             self._cache_attr("_group_names")
 
         return self._group_names
 
-    def is_member_of(self, group_dn):
+    def is_member_of(self, group_dn: str) -> bool:
         """
         Returns true if our user is a member of the given group.
         """
@@ -933,6 +1015,9 @@ class _LDAPUserGroups:
         # If we have self._group_dns, we'll use it. Otherwise, we'll try to
         # avoid the cost of loading it.
         if self._group_dns is None:
+            if self._group_type is None:
+                raise TypeError("The group type should not be None")
+
             is_member = self._group_type.is_member(self._ldap_user, group_dn)
 
         if is_member is None:
@@ -946,7 +1031,7 @@ class _LDAPUserGroups:
 
         return is_member
 
-    def get_group_dns(self):
+    def get_group_dns(self) -> Set[str]:
         """
         Returns a (cached) set of the distinguished names in self._group_infos.
         """
@@ -956,31 +1041,38 @@ class _LDAPUserGroups:
 
         return self._group_dns
 
-    def _get_group_infos(self):
+    def _get_group_infos(
+        self,
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
         """
         Returns a (cached) list of group_info structures for the groups that our
         user is a member of.
         """
         if self._group_infos is None:
+            if self._group_type is None:
+                raise TypeError("The group type should not be None")
+            if self._group_search is None:
+                raise TypeError("The group search should not be None")
+
             self._group_infos = self._group_type.user_groups(
                 self._ldap_user, self._group_search
             )
 
         return self._group_infos
 
-    def _load_cached_attr(self, attr_name):
+    def _load_cached_attr(self, attr_name: str) -> None:
         if self.settings.CACHE_TIMEOUT > 0:
             key = self._cache_key(attr_name)
             value = cache.get(key)
             setattr(self, attr_name, value)
 
-    def _cache_attr(self, attr_name):
+    def _cache_attr(self, attr_name: str) -> None:
         if self.settings.CACHE_TIMEOUT > 0:
             key = self._cache_key(attr_name)
             value = getattr(self, attr_name, None)
             cache.set(key, value, self.settings.CACHE_TIMEOUT)
 
-    def _cache_key(self, attr_name):
+    def _cache_key(self, attr_name: str) -> str:
         """
         Memcache keys can't have spaces in them, so we'll remove them from the
         DN for maximum compatibility.
@@ -998,7 +1090,7 @@ class LDAPSettings:
     if they are not specified by the configuration.
     """
 
-    _prefix = "AUTH_LDAP_"
+    _prefix: str = "AUTH_LDAP_"
 
     defaults = {
         "ALWAYS_UPDATE_USER": True,
@@ -1027,41 +1119,111 @@ class LDAPSettings:
         "USER_SEARCH": None,
     }
 
-    def __init__(self, prefix="AUTH_LDAP_", defaults={}):
+    def __init__(
+        self, prefix: str = "AUTH_LDAP_", defaults: Optional[Dict[str, Any]] = None
+    ) -> None:
         """
         Loads our settings from django.conf.settings, applying defaults for any
         that are omitted.
         """
         self._prefix = prefix
 
-        defaults = dict(self.defaults, **defaults)
+        defaults = dict(self.defaults, **(defaults or dict()))  # type: ignore
 
-        for name, default in defaults.items():
-            value = getattr(django.conf.settings, prefix + name, default)
-            setattr(self, name, value)
+        self.ALWAYS_UPDATE_USER: bool = self._get_setting(
+            "ALWAYS_UPDATE_USER", defaults, True
+        )
+        self.AUTHORIZE_ALL_USERS: bool = self._get_setting(
+            "AUTHORIZE_ALL_USERS", defaults, False
+        )
+        self.BIND_AS_AUTHENTICATING_USER: bool = self._get_setting(
+            "BIND_AS_AUTHENTICATING_USER", defaults, False
+        )
+        self.BIND_DN: str = self._get_setting("BIND_DN", defaults, "")
+        self.BIND_PASSWORD: str = self._get_setting("BIND_PASSWORD", defaults, "")
+        self.CACHE_TIMEOUT: int = self._get_setting("CACHE_TIMEOUT", defaults, 0)
+        self.CONNECTION_OPTIONS: Dict[int, Any] = self._get_setting(
+            "CONNECTION_OPTIONS", defaults, dict()
+        )
+        self.DENY_GROUP: Optional[str] = self._get_setting("DENY_GROUP", defaults, None)
+        self.FIND_GROUP_PERMS: bool = self._get_setting(
+            "FIND_GROUP_PERMS", defaults, False
+        )
+        self.GLOBAL_OPTIONS: Dict[int, Any] = self._get_setting(
+            "GLOBAL_OPTIONS", defaults, dict()
+        )
+        self.GROUP_SEARCH: Optional[AbstractLDAPSearch] = self._get_setting(
+            "GROUP_SEARCH", defaults, None
+        )
+        self.GROUP_TYPE: Optional[LDAPGroupType] = self._get_setting(
+            "GROUP_TYPE", defaults, None
+        )
+        self.MIRROR_GROUPS: Union[bool, Collection[str], None] = self._get_setting(
+            "MIRROR_GROUPS", defaults, None
+        )
+        self.MIRROR_GROUPS_EXCEPT: Optional[Collection[str]] = self._get_setting(
+            "MIRROR_GROUPS_EXCEPT", defaults, None
+        )
+        self.NO_NEW_USERS: bool = self._get_setting("NO_NEW_USERS", defaults, False)
+        self.PERMIT_EMPTY_PASSWORD: bool = self._get_setting(
+            "PERMIT_EMPTY_PASSWORD", defaults, False
+        )
+        self.REQUIRE_GROUP: Union[str, LDAPGroupQuery, None] = self._get_setting(
+            "REQUIRE_GROUP", defaults, None
+        )
+        self.SERVER_URI: Union[
+            str, Callable[[Optional[HttpRequest]], str]
+        ] = self._get_setting("SERVER_URI", defaults, "ldap://localhost")
+        self.START_TLS: bool = self._get_setting("START_TLS", defaults, False)
+        self.USER_QUERY_FIELD: Optional[str] = self._get_setting(
+            "USER_QUERY_FIELD", defaults, None
+        )
+        self.USER_ATTRLIST: Optional[Collection[str]] = self._get_setting(
+            "USER_ATTRLIST", defaults, None
+        )
+        self.USER_ATTR_MAP: Dict[str, str] = self._get_setting(
+            "USER_ATTR_MAP", defaults, dict()
+        )
+        self.USER_DN_TEMPLATE: Optional[str] = self._get_setting(
+            "USER_DN_TEMPLATE", defaults, None
+        )
+        self.USER_FLAGS_BY_GROUP: Dict[
+            str, Union[str, LDAPGroupQuery]
+        ] = self._get_setting("USER_FLAGS_BY_GROUP", defaults, dict())
+        self.USER_SEARCH: Optional[AbstractLDAPSearch] = self._get_setting(
+            "USER_SEARCH", defaults, None
+        )
 
         # Compatibility with old caching settings.
-        if getattr(
-            django.conf.settings,
-            self._name("CACHE_GROUPS"),
-            defaults.get("CACHE_GROUPS"),
+        if (
+            getattr(
+                django.conf.settings,
+                self._name("CACHE_GROUPS"),
+                defaults.get("CACHE_GROUPS"),
+            )
+            is not None
         ):
             warnings.warn(
                 "Found deprecated setting AUTH_LDAP_CACHE_GROUP. Use "
                 "AUTH_LDAP_CACHE_TIMEOUT instead.",
                 DeprecationWarning,
             )
-            self.CACHE_TIMEOUT = getattr(
-                django.conf.settings,
-                self._name("GROUP_CACHE_TIMEOUT"),
-                defaults.get("GROUP_CACHE_TIMEOUT", 3600),
+            self.CACHE_TIMEOUT = self._get_setting(
+                "GROUP_CACHE_TIMEOUT", defaults, 3600
             )
 
-    def _name(self, suffix):
+    def _name(self, suffix: str) -> str:
         return self._prefix + suffix
 
+    def _get_setting(self, suffix: str, defaults: Dict[str, Any], default: T) -> T:
+        return getattr(
+            django.conf.settings,
+            self._name(suffix),
+            defaults.get(suffix, default),
+        )
 
-def valid_cache_key(key):
+
+def valid_cache_key(key: str) -> str:
     """
     Sanitizes a cache key for memcached.
     """

--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -31,10 +31,33 @@ notes on naming conventions.
 
 import logging
 import pprint
+from abc import ABC, abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    ItemsView,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    ValuesView,
+    cast,
+)
 
 import ldap
 import ldap.filter
 from django.utils.tree import Node
+from ldap.ldapobject import LDAPObject
+
+if TYPE_CHECKING:
+    from django_auth_ldap.backend import _LDAPUser, _LDAPUserGroups
 
 
 class ConfigurationWarning(UserWarning):
@@ -46,12 +69,12 @@ class _LDAPConfig:
     A private class that loads and caches some global objects.
     """
 
-    logger = None
+    logger: Optional[logging.Logger] = None
 
-    _ldap_configured = False
+    _ldap_configured: bool = False
 
     @classmethod
-    def get_ldap(cls, global_options=None):
+    def get_ldap(cls, global_options: Optional[Dict[int, Any]] = None) -> ldap:
         """
         Returns the configured ldap module.
         """
@@ -65,7 +88,7 @@ class _LDAPConfig:
         return ldap
 
     @classmethod
-    def get_logger(cls):
+    def get_logger(cls) -> logging.Logger:
         """
         Initializes and returns our logger instance.
         """
@@ -77,10 +100,115 @@ class _LDAPConfig:
 
 
 # Our global logger
-logger = _LDAPConfig.get_logger()
+logger: logging.Logger = _LDAPConfig.get_logger()
 
 
-class LDAPSearch:
+class AbstractLDAPSearch(ABC):
+    """
+    The abstract base class for ldap searches.
+    """
+
+    @abstractmethod
+    def search_with_additional_terms(
+        self, term_dict: Dict[str, str], escape: bool = True
+    ) -> "AbstractLDAPSearch":
+        """
+        Returns a new search object with additional search terms and-ed to the
+        filter string. term_dict maps attribute names to assertion values. If
+        you don't want the values escaped, pass escape=False.
+        """
+        pass
+
+    @abstractmethod
+    def search_with_additional_term_string(
+        self, filterstr: str
+    ) -> "AbstractLDAPSearch":
+        """
+        Returns a new search object with filterstr and-ed to the original filter
+        string. The caller is responsible for passing in a properly escaped
+        string.
+        """
+        pass
+
+    def execute(
+        self,
+        connection: LDAPObject,
+        filterargs: Union[Tuple[Any, ...], Mapping[str, Any]] = (),
+        escape: bool = True,
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
+        """
+        Executes the search on the given connection (an LDAPObject). filterargs
+        is an object that will be used for expansion of the filter string.
+        If escape is True, values in filterargs will be escaped.
+        """
+        self._search(connection, filterargs, escape)
+
+        return self._result(connection)
+
+    @abstractmethod
+    def _abandon(self, connection: LDAPObject) -> None:
+        """
+        Abandon a previous asynchronous search.
+        """
+        pass
+
+    @abstractmethod
+    def _search(
+        self,
+        connection: LDAPObject,
+        filterargs: Union[Tuple[Any, ...], Mapping[str, Any]] = (),
+        escape: bool = True,
+    ) -> None:
+        """
+        Begins an asynchronous search and returns the message id to retrieve
+        the results.
+
+        filterargs is an object that will be used for expansion of the filter
+        string. If escape is True, values in filterargs will be escaped.
+        """
+        pass
+
+    @abstractmethod
+    def _result(
+        self, connection: LDAPObject
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
+        """
+        Returns the result of a previous asynchronous query or an empty array
+        if no search has been initiated.
+
+        The python-ldap library returns utf8-encoded strings. For the sake of
+        sanity, this method will decode all result strings and return them as
+        Unicode.
+        """
+        pass
+
+    @classmethod
+    def _escape_filterargs(
+        cls, filterargs: Union[Tuple[Any, ...], Mapping[str, Any]]
+    ) -> Union[Tuple[Any, ...], Mapping[str, Any]]:
+        """
+        Escapes all string values in filterargs and all others remain the same.
+
+        filterargs is a value suitable for Django's string formatting operator
+        (%), which means it's either a tuple or a dict. This return a new tuple
+        or dict with all values escaped for use in filter strings.
+        """
+        if isinstance(filterargs, tuple):
+            filterargs = tuple(
+                ldap.filter.escape_filter_chars(str(value)) for value in filterargs
+            )
+        elif isinstance(filterargs, Mapping):
+            filterargs = dict(
+                (key, ldap.filter.escape_filter_chars(str(value)))
+                for key, value in filterargs.items()
+            )
+        else:
+            raise TypeError("filterargs must be a tuple or mapping.")
+
+        return filterargs
+
+
+class LDAPSearch(AbstractLDAPSearch):
     """
     Public class that holds a set of LDAP search parameters. Objects of this
     class should be considered immutable. Only the initialization method is
@@ -88,26 +216,30 @@ class LDAPSearch:
     methods to refine and execute the search.
     """
 
-    def __init__(self, base_dn, scope, filterstr="(objectClass=*)", attrlist=None):
+    def __init__(
+        self,
+        base_dn: str,
+        scope: int,
+        filterstr: str = "(objectClass=*)",
+        attrlist: Optional[Collection[str]] = None,
+    ) -> None:
         """
         These parameters are the same as the first three parameters to
         ldap.search_s.
         """
-        self.base_dn = base_dn
-        self.scope = scope
-        self.filterstr = filterstr
-        self.attrlist = attrlist
-        self.ldap = _LDAPConfig.get_ldap()
+        self.base_dn: str = base_dn
+        self.scope: int = scope
+        self.filterstr: str = filterstr
+        self.attrlist: Optional[Collection[str]] = attrlist
+        self.ldap: ldap = _LDAPConfig.get_ldap()
+        self.msgid: Optional[int] = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}: {}>".format(type(self).__name__, self.base_dn)
 
-    def search_with_additional_terms(self, term_dict, escape=True):
-        """
-        Returns a new search object with additional search terms and-ed to the
-        filter string. term_dict maps attribute names to assertion values. If
-        you don't want the values escaped, pass escape=False.
-        """
+    def search_with_additional_terms(
+        self, term_dict: Dict[str, str], escape: bool = True
+    ) -> "LDAPSearch":
         term_strings = [self.filterstr]
 
         for name, value in term_dict.items():
@@ -119,167 +251,143 @@ class LDAPSearch:
 
         return type(self)(self.base_dn, self.scope, filterstr, attrlist=self.attrlist)
 
-    def search_with_additional_term_string(self, filterstr):
-        """
-        Returns a new search object with filterstr and-ed to the original filter
-        string. The caller is responsible for passing in a properly escaped
-        string.
-        """
+    def search_with_additional_term_string(self, filterstr: str) -> "LDAPSearch":
         filterstr = "(&{}{})".format(self.filterstr, filterstr)
 
         return type(self)(self.base_dn, self.scope, filterstr, attrlist=self.attrlist)
 
-    def execute(self, connection, filterargs=(), escape=True):
-        """
-        Executes the search on the given connection (an LDAPObject). filterargs
-        is an object that will be used for expansion of the filter string.
-        If escape is True, values in filterargs will be escaped.
+    def _abandon(self, connection: LDAPObject) -> None:
+        if self.msgid is not None:
+            connection.abandon(self.msgid)
+            self.msgid = None
 
-        The python-ldap library returns utf8-encoded strings. For the sake of
-        sanity, this method will decode all result strings and return them as
-        Unicode.
-        """
+    def _search(
+        self,
+        connection: LDAPObject,
+        filterargs: Union[Tuple[Any, ...], Mapping[str, Any]] = (),
+        escape: bool = True,
+    ) -> None:
+        self._abandon(connection)
+
         if escape:
             filterargs = self._escape_filterargs(filterargs)
 
+        filterstr = self.filterstr % filterargs
+
         try:
-            filterstr = self.filterstr % filterargs
-            results = connection.search_s(
+            self.msgid = connection.search(
                 self.base_dn, self.scope, filterstr, self.attrlist
             )
         except ldap.LDAPError as e:
-            results = []
-            logger.error(
-                "search_s('{}', {}, '{}') raised {}".format(
-                    self.base_dn, self.scope, filterstr, pprint.pformat(e)
-                )
-            )
-
-        return self._process_results(results)
-
-    def _begin(self, connection, filterargs=(), escape=True):
-        """
-        Begins an asynchronous search and returns the message id to retrieve
-        the results.
-
-        filterargs is an object that will be used for expansion of the filter
-        string. If escape is True, values in filterargs will be escaped.
-
-        """
-        if escape:
-            filterargs = self._escape_filterargs(filterargs)
-
-        try:
-            filterstr = self.filterstr % filterargs
-            msgid = connection.search(
-                self.base_dn, self.scope, filterstr, self.attrlist
-            )
-        except ldap.LDAPError as e:
-            msgid = None
             logger.error(
                 "search('{}', {}, '{}') raised {}".format(
                     self.base_dn, self.scope, filterstr, pprint.pformat(e)
                 )
             )
 
-        return msgid
+    def _result(self, connection: LDAPObject) -> List[Tuple[str, Dict[str, List[str]]]]:
+        if self.msgid is None:
+            raise RuntimeError(
+                "The search has either not been initiated, abandoned,"
+                " or the results have already been fetched"
+            )
 
-    def _results(self, connection, msgid):
-        """
-        Returns the result of a previous asynchronous query.
-        """
         try:
-            kind, results = connection.result(msgid)
+            kind, results = connection.result(self.msgid)
             if kind not in (ldap.RES_SEARCH_ENTRY, ldap.RES_SEARCH_RESULT):
                 results = []
+            else:
+                results = self._process_results(results)
+                result_dns = [result[0] for result in results]
+
+                logger.debug(
+                    "search_s('{}', {}, '{}') returned {} objects: {}".format(
+                        self.base_dn,
+                        self.scope,
+                        self.filterstr,
+                        len(result_dns),
+                        "; ".join(result_dns),
+                    )
+                )
         except ldap.LDAPError as e:
             results = []
-            logger.error("result({}) raised {}".format(msgid, pprint.pformat(e)))
+            logger.error("result({}) raised {}".format(self.msgid, pprint.pformat(e)))
 
-        return self._process_results(results)
+        self.msgid = None
 
-    def _escape_filterargs(self, filterargs):
-        """
-        Escapes values in filterargs.
+        return results
 
-        filterargs is a value suitable for Django's string formatting operator
-        (%), which means it's either a tuple or a dict. This return a new tuple
-        or dict with all values escaped for use in filter strings.
-
-        """
-        if isinstance(filterargs, tuple):
-            filterargs = tuple(
-                self.ldap.filter.escape_filter_chars(value) for value in filterargs
-            )
-        elif isinstance(filterargs, dict):
-            filterargs = {
-                key: self.ldap.filter.escape_filter_chars(value)
-                for key, value in filterargs.items()
-            }
-        else:
-            raise TypeError("filterargs must be a tuple or dict.")
-
-        return filterargs
-
-    def _process_results(self, results):
+    @classmethod
+    def _process_results(
+        cls,
+        results: List[
+            Tuple[
+                Union[str, bytes, None],
+                Dict[Union[str, bytes], List[Union[str, bytes]]],
+            ]
+        ],
+    ) -> List[Tuple[str, Dict[str, List[str]]]]:
         """
         Returns a sanitized copy of raw LDAP results. This scrubs out
         references, decodes utf8, normalizes DNs, etc.
         """
         results = [r for r in results if r[0] is not None]
-        results = _DeepStringCoder("utf-8").decode(results)
-
-        # The normal form of a DN is lower case.
-        results = [(r[0].lower(), r[1]) for r in results]
-
-        result_dns = [result[0] for result in results]
-        logger.debug(
-            "search_s('{}', {}, '{}') returned {} objects: {}".format(
-                self.base_dn,
-                self.scope,
-                self.filterstr,
-                len(result_dns),
-                "; ".join(result_dns),
-            )
+        decoded_results = cast(
+            List[Tuple[str, Dict[str, List[str]]]],
+            _DeepStringCoder("utf-8").decode(results),
         )
 
-        return results
+        # The normal form of a DN is lower case.
+        decoded_results = [(r[0].lower(), r[1]) for r in decoded_results]
+
+        return decoded_results
 
 
-class LDAPSearchUnion:
+class LDAPSearchUnion(AbstractLDAPSearch):
     """
     A compound search object that returns the union of the results. Instantiate
-    it with one or more LDAPSearch objects.
+    it with one or more AbstractLDAPSearch objects.
     """
 
-    def __init__(self, *args):
-        self.searches = args
-        self.ldap = _LDAPConfig.get_ldap()
+    def __init__(self, *args: AbstractLDAPSearch) -> None:
+        self.searches: Tuple[AbstractLDAPSearch, ...] = args
+        self.ldap: ldap = _LDAPConfig.get_ldap()
 
-    def search_with_additional_terms(self, term_dict, escape=True):
-        searches = [
+    def search_with_additional_terms(
+        self, term_dict: Dict[str, str], escape: bool = True
+    ) -> "LDAPSearchUnion":
+        searches = tuple(
             s.search_with_additional_terms(term_dict, escape) for s in self.searches
-        ]
+        )
 
         return type(self)(*searches)
 
-    def search_with_additional_term_string(self, filterstr):
-        searches = [
+    def search_with_additional_term_string(self, filterstr: str) -> "LDAPSearchUnion":
+        searches = tuple(
             s.search_with_additional_term_string(filterstr) for s in self.searches
-        ]
+        )
 
         return type(self)(*searches)
 
-    def execute(self, connection, filterargs=(), escape=True):
-        msgids = [
-            search._begin(connection, filterargs, escape) for search in self.searches
-        ]
-        results = {}
+    def _abandon(self, connection: LDAPObject) -> None:
+        for search in self.searches:
+            search._abandon(connection)
 
-        for search, msgid in zip(self.searches, msgids):
-            if msgid is not None:
-                result = search._results(connection, msgid)
-                results.update(dict(result))
+    def _search(
+        self,
+        connection: LDAPObject,
+        filterargs: Union[Tuple[Any, ...], Mapping[str, Any]] = (),
+        escape: bool = True,
+    ) -> None:
+        for search in self.searches:
+            search._search(connection, filterargs, escape)
+
+    def _result(self, connection: LDAPObject) -> ItemsView[str, Dict[str, List[str]]]:
+        results = dict()
+
+        for search in self.searches:
+            result = search._result(connection)
+            results.update(dict(result))
 
         return results.items()
 
@@ -291,29 +399,32 @@ class _DeepStringCoder:
     python-ldap.
     """
 
-    def __init__(self, encoding):
-        self.encoding = encoding
-        self.ldap = _LDAPConfig.get_ldap()
+    def __init__(self, encoding: str) -> None:
+        self.encoding: str = encoding
+        self.ldap: ldap = _LDAPConfig.get_ldap()
 
-    def decode(self, value):
+    def decode(
+        self, value: Union[bytes, List, tuple, Dict, Any]
+    ) -> Union[str, List, tuple, ldap.cidict.cidict, Any]:
         try:
             if isinstance(value, bytes):
                 value = value.decode(self.encoding)
-            elif isinstance(value, list):
-                value = self._decode_list(value)
+            elif isinstance(value, List):
+                value = list(self._decode_iterable(value))
             elif isinstance(value, tuple):
-                value = tuple(self._decode_list(value))
-            elif isinstance(value, dict):
+                value = tuple(self._decode_iterable(value))
+            elif isinstance(value, Dict):
                 value = self._decode_dict(value)
         except UnicodeDecodeError:
             pass
 
         return value
 
-    def _decode_list(self, value):
-        return [self.decode(v) for v in value]
+    def _decode_iterable(self, iterable: Iterable) -> Iterator:
+        for element in iterable:
+            yield self.decode(element)
 
-    def _decode_dict(self, value):
+    def _decode_dict(self, value: Dict) -> ldap.cidict.cidict:
         # Attribute dictionaries should be case-insensitive. python-ldap
         # defines this, although for some reason, it doesn't appear to use it
         # for search results.
@@ -325,7 +436,7 @@ class _DeepStringCoder:
         return decoded
 
 
-class LDAPGroupType:
+class LDAPGroupType(ABC):
     """
     This is an abstract base class for classes that determine LDAP group
     membership. A group can mean many different things in LDAP, so we will need
@@ -340,11 +451,14 @@ class LDAPGroupType:
     This will be a mock object during unit tests.
     """
 
-    def __init__(self, name_attr="cn"):
-        self.name_attr = name_attr
-        self.ldap = _LDAPConfig.get_ldap()
+    def __init__(self, name_attr: str = "cn") -> None:
+        self.name_attr: str = name_attr
+        self.ldap: ldap = _LDAPConfig.get_ldap()
 
-    def user_groups(self, ldap_user, group_search):
+    @abstractmethod
+    def user_groups(
+        self, ldap_user: "_LDAPUser", group_search: AbstractLDAPSearch
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
         """
         Returns a list of group_info structures, each one a group to which
         ldap_user belongs. group_search is an LDAPSearch object that returns all
@@ -359,9 +473,9 @@ class LDAPGroupType:
 
         This is the primitive method in the API and must be implemented.
         """
-        return []
+        pass
 
-    def is_member(self, ldap_user, group_dn):
+    def is_member(self, ldap_user: "_LDAPUser", group_dn: str) -> Optional[bool]:
         """
         This method is an optimization for determining group membership without
         loading all of the user's groups. Subclasses that are able to do this
@@ -374,7 +488,9 @@ class LDAPGroupType:
         """
         return None
 
-    def group_name_from_info(self, group_info):
+    def group_name_from_info(
+        self, group_info: Tuple[str, Dict[str, List[str]]]
+    ) -> Optional[str]:
         """
         Given the (DN, attrs) 2-tuple of an LDAP group, this returns the name of
         the Django group. This may return None to indicate that a particular
@@ -385,11 +501,9 @@ class LDAPGroupType:
         parameter.
         """
         try:
-            name = group_info[1][self.name_attr][0]
+            return group_info[1][self.name_attr][0]
         except (KeyError, IndexError):
-            name = None
-
-        return name
+            return None
 
 
 class PosixGroupType(LDAPGroupType):
@@ -397,12 +511,15 @@ class PosixGroupType(LDAPGroupType):
     An LDAPGroupType subclass that handles groups of class posixGroup.
     """
 
-    def user_groups(self, ldap_user, group_search):
+    def user_groups(
+        self, ldap_user: "_LDAPUser", group_search: AbstractLDAPSearch
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
         """
         Searches for any group that is either the user's primary or contains the
         user as a member.
         """
-        groups = []
+        if ldap_user.attrs is None:
+            raise TypeError("The attrs of the LDAP user should not be None")
 
         try:
             user_uid = ldap_user.attrs["uid"][0]
@@ -421,15 +538,18 @@ class PosixGroupType(LDAPGroupType):
             search = group_search.search_with_additional_term_string(filterstr)
             groups = search.execute(ldap_user.connection)
         except (KeyError, IndexError):
-            pass
+            groups = []
 
         return groups
 
-    def is_member(self, ldap_user, group_dn):
+    def is_member(self, ldap_user: "_LDAPUser", group_dn: str) -> bool:
         """
         Returns True if the group is the user's primary group or if the user is
         listed in the group's memberUid attribute.
         """
+        if ldap_user.attrs is None:
+            raise TypeError("The attrs of the LDAP user should not be None")
+
         try:
             user_uid = ldap_user.attrs["uid"][0]
 
@@ -459,33 +579,39 @@ class MemberDNGroupType(LDAPGroupType):
     A group type that stores lists of members as distinguished names.
     """
 
-    def __init__(self, member_attr, name_attr="cn"):
+    def __init__(self, member_attr: str, name_attr: str = "cn") -> None:
         """
         member_attr is the attribute on the group object that holds the list of
         member DNs.
         """
-        self.member_attr = member_attr
+        self.member_attr: str = member_attr
 
         super().__init__(name_attr)
 
     def __repr__(self):
         return "<{}: {}>".format(type(self).__name__, self.member_attr)
 
-    def user_groups(self, ldap_user, group_search):
+    def user_groups(
+        self, ldap_user: "_LDAPUser", group_search: AbstractLDAPSearch
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
+        if ldap_user.dn is None:
+            raise TypeError("The dn of the LDAP user should not be None")
+
         search = group_search.search_with_additional_terms(
             {self.member_attr: ldap_user.dn}
         )
         return search.execute(ldap_user.connection)
 
-    def is_member(self, ldap_user, group_dn):
+    def is_member(self, ldap_user: "_LDAPUser", group_dn: str) -> bool:
+        if ldap_user.dn is None:
+            raise TypeError("The dn of the LDAP user should not be None")
+
         try:
-            result = ldap_user.connection.compare_s(
+            return ldap_user.connection.compare_s(
                 group_dn, self.member_attr, ldap_user.dn.encode()
             )
         except (ldap.UNDEFINED_TYPE, ldap.NO_SUCH_ATTRIBUTE):
-            result = 0
-
-        return result
+            return False
 
 
 class NestedMemberDNGroupType(LDAPGroupType):
@@ -495,23 +621,28 @@ class NestedMemberDNGroupType(LDAPGroupType):
     it's left unimplemented.
     """
 
-    def __init__(self, member_attr, name_attr="cn"):
+    def __init__(self, member_attr: str, name_attr: str = "cn") -> None:
         """
         member_attr is the attribute on the group object that holds the list of
         member DNs.
         """
-        self.member_attr = member_attr
+        self.member_attr: str = member_attr
 
         super().__init__(name_attr)
 
-    def user_groups(self, ldap_user, group_search):
+    def user_groups(
+        self, ldap_user: "_LDAPUser", group_search: AbstractLDAPSearch
+    ) -> ValuesView[Tuple[str, Dict[str, List[str]]]]:
         """
         This searches for all of a user's groups from the bottom up. In other
         words, it returns the groups that the user belongs to, the groups that
         those groups belong to, etc. Circular references will be detected and
         pruned.
         """
-        group_info_map = {}  # Maps group_dn to group_info of groups we've found
+        if ldap_user.dn is None:
+            raise TypeError("The dn of the LDAP user should not be None")
+
+        group_info_map = dict()  # Maps group_dn to group_info of groups we've found
         member_dn_set = {ldap_user.dn}  # Member DNs to search with next
         handled_dn_set = set()  # Member DNs that we've already searched with
 
@@ -529,7 +660,12 @@ class NestedMemberDNGroupType(LDAPGroupType):
 
         return group_info_map.values()
 
-    def find_groups_with_any_member(self, member_dn_set, group_search, connection):
+    def find_groups_with_any_member(
+        self,
+        member_dn_set: Set[str],
+        group_search: AbstractLDAPSearch,
+        connection: LDAPObject,
+    ) -> Collection[Tuple[str, Dict[str, List[str]]]]:
         terms = [
             "({}={})".format(self.member_attr, self.ldap.filter.escape_filter_chars(dn))
             for dn in member_dn_set
@@ -546,7 +682,7 @@ class GroupOfNamesType(MemberDNGroupType):
     An LDAPGroupType subclass that handles groups of class groupOfNames.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("member", name_attr)
 
 
@@ -556,7 +692,7 @@ class NestedGroupOfNamesType(NestedMemberDNGroupType):
     nested group references.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("member", name_attr)
 
 
@@ -565,7 +701,7 @@ class GroupOfUniqueNamesType(MemberDNGroupType):
     An LDAPGroupType subclass that handles groups of class groupOfUniqueNames.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("uniqueMember", name_attr)
 
 
@@ -575,7 +711,7 @@ class NestedGroupOfUniqueNamesType(NestedMemberDNGroupType):
     with nested group references.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("uniqueMember", name_attr)
 
 
@@ -584,7 +720,7 @@ class ActiveDirectoryGroupType(MemberDNGroupType):
     An LDAPGroupType subclass that handles Active Directory groups.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("member", name_attr)
 
 
@@ -594,7 +730,7 @@ class NestedActiveDirectoryGroupType(NestedMemberDNGroupType):
     group references.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("member", name_attr)
 
 
@@ -603,7 +739,7 @@ class OrganizationalRoleGroupType(MemberDNGroupType):
     An LDAPGroupType subclass that handles groups of class organizationalRole.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("roleOccupant", name_attr)
 
 
@@ -613,7 +749,7 @@ class NestedOrganizationalRoleGroupType(NestedMemberDNGroupType):
     with nested group references.
     """
 
-    def __init__(self, name_attr="cn"):
+    def __init__(self, name_attr: str = "cn") -> None:
         super().__init__("roleOccupant", name_attr)
 
 
@@ -626,8 +762,7 @@ class LDAPGroupQuery(Node):
     group DN as the only argument. These queries can then be combined with the
     ``&``, ``|``, and ``~`` operators.
 
-    :param str group_dn: The DN of a group to test for membership.
-
+    :param str group_dns: The DN of a group to test for membership.
     """
 
     # Connection types
@@ -637,23 +772,23 @@ class LDAPGroupQuery(Node):
 
     _CONNECTORS = [AND, OR]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(children=list(args) + list(kwargs.items()))
+    def __init__(self, *group_dns: str) -> None:
+        super().__init__(children=list(group_dns))
 
-    def __and__(self, other):
+    def __and__(self, other: "LDAPGroupQuery") -> "LDAPGroupQuery":
         return self._combine(other, self.AND)
 
-    def __or__(self, other):
+    def __or__(self, other: "LDAPGroupQuery") -> "LDAPGroupQuery":
         return self._combine(other, self.OR)
 
-    def __invert__(self):
+    def __invert__(self) -> "LDAPGroupQuery":
         obj = type(self)()
         obj.add(self, self.AND)
         obj.negate()
 
         return obj
 
-    def _combine(self, other, conn):
+    def _combine(self, other: "LDAPGroupQuery", conn: str) -> "LDAPGroupQuery":
         if not isinstance(other, LDAPGroupQuery):
             raise TypeError(other)
         if conn not in self._CONNECTORS:
@@ -666,7 +801,9 @@ class LDAPGroupQuery(Node):
 
         return obj
 
-    def resolve(self, ldap_user, groups=None):
+    def resolve(
+        self, ldap_user: "_LDAPUser", groups: Optional["_LDAPUserGroups"] = None
+    ) -> bool:
         if groups is None:
             groups = ldap_user._get_groups()
 
@@ -677,7 +814,7 @@ class LDAPGroupQuery(Node):
         return result
 
     @property
-    def aggregator(self):
+    def aggregator(self) -> Callable[[Iterable[object]], bool]:
         """
         Returns a function for aggregating a sequence of sub-results.
         """
@@ -690,7 +827,9 @@ class LDAPGroupQuery(Node):
 
         return aggregator
 
-    def _resolve_children(self, ldap_user, groups):
+    def _resolve_children(
+        self, ldap_user: "_LDAPUser", groups: "_LDAPUserGroups"
+    ) -> Iterator[bool]:
         """
         Generates the query result for each child.
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,3 +44,8 @@ max-line-length = 88
 
 [isort]
 profile = black
+
+[mypy]
+ignore_missing_imports = True
+no_implicit_optional = True
+strict_equality = True

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -416,7 +416,7 @@ class LDAPTest(TestCase):
         self.assertIsNotNone(user)
         self.assertEqual(User.objects.count(), user_count + 1)
 
-    @spy_ldap("search_s")
+    @spy_ldap("search")
     def test_search_bind_escaped(self, mock):
         """ Search for a username that requires escaping. """
         self._init_settings(
@@ -589,7 +589,7 @@ class LDAPTest(TestCase):
         with self.assertRaisesMessage(Exception, "Oops..."):
             backend.populate_user("alice")
 
-    @spy_ldap("search_s")
+    @spy_ldap("search")
     def test_populate_with_attrlist(self, mock):
         self._init_settings(
             USER_DN_TEMPLATE="uid=%(user)s,ou=people,o=test",
@@ -1133,7 +1133,7 @@ class LDAPTest(TestCase):
 
         self.assertEqual(backend.get_group_permissions(alice), set())
 
-    @spy_ldap("search_s")
+    @spy_ldap("search")
     def test_group_cache(self, mock):
         self._init_settings(
             USER_DN_TEMPLATE="uid=%(user)s,ou=people,o=test",
@@ -1507,17 +1507,24 @@ class LDAPTest(TestCase):
         self.assertIs(backend.has_perm(alice, "auth.add_user"), True)
         self.assertIs(backend.has_module_perms(alice, "auth"), True)
 
-    @mock.patch("ldap.ldapobject.SimpleLDAPObject.search_s")
-    def test_search_attrlist(self, mock_search):
+    def test_search_attrlist(self):
         backend = get_backend()
         connection = backend.ldap.initialize(self.server.ldap_uri, bytes_mode=False)
         search = LDAPSearch(
             "ou=people,o=test", ldap.SCOPE_SUBTREE, "(uid=alice)", ["*", "+"]
         )
-        search.execute(connection)
-        mock_search.assert_called_once_with(
-            "ou=people,o=test", ldap.SCOPE_SUBTREE, "(uid=alice)", ["*", "+"]
-        )
+
+        with mock.patch("ldap.ldapobject.SimpleLDAPObject.search") as mock_search:
+            with mock.patch("ldap.ldapobject.SimpleLDAPObject.result") as mock_result:
+                mock_search.return_value = 123
+                mock_result.return_value = (ldap.RES_SEARCH_RESULT, [])
+
+                search.execute(connection)
+
+                mock_search.assert_called_once_with(
+                    "ou=people,o=test", ldap.SCOPE_SUBTREE, "(uid=alice)", ["*", "+"]
+                )
+                mock_result.assert_called_once_with(mock_search.return_value)
 
     def test_override_authenticate_access_ldap_user(self):
         self._init_settings(USER_DN_TEMPLATE="uid=%(user)s,ou=people,o=test")
@@ -1531,7 +1538,7 @@ class LDAPTest(TestCase):
         user = backend.authenticate(None, username="alice", password="password")
         self.assertEqual(user.ldap_user.foo, "bar")
 
-    @spy_ldap("search_s")
+    @spy_ldap("search")
     def test_dn_not_cached(self, mock):
         self._init_settings(
             USER_SEARCH=LDAPSearch(
@@ -1546,7 +1553,7 @@ class LDAPTest(TestCase):
         # DN is not cached.
         self.assertIsNone(cache.get("django_auth_ldap.user_dn.alice"))
 
-    @spy_ldap("search_s")
+    @spy_ldap("search")
     def test_dn_cached(self, mock):
         self._init_settings(
             USER_SEARCH=LDAPSearch(

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     black
     flake8
     isort
+    mypy
     docs
     django22
     django30
@@ -30,6 +31,11 @@ skip_install = true
 [testenv:isort]
 deps = isort>=5.0.1
 commands = isort --check --diff .
+skip_install = true
+
+[testenv:mypy]
+deps = mypy>=0.800
+commands = mypy django_auth_ldap
 skip_install = true
 
 [testenv:docs]


### PR DESCRIPTION
## Important: this PR only exists to split up the PR #208

- _LDAPUser._normalize_mirror_settings() no longer edits LDAPSettings and instead returns the normalized sets