### PR TITLE
Set DEFAULT_AUTO_FIELD in test project

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,5 +3,6 @@ SECRET_KEY = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 INSTALLED_APPS = ("django.contrib.auth", "django.contrib.contenttypes", "tests")
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTHENTICATION_BACKENDS = ["django_auth_ldap.backend.LDAPBackend"]


### PR DESCRIPTION
Avoids warning:

```
tests.TestUser: (models.W042) Auto-created primary key used when not
defining a primary key type, by default 'django.db.models.AutoField'.
    HINT: Configure the DEFAULT_AUTO_FIELD setting or the
        AppConfig.default_auto_field attribute to point to a subclass of
        AutoField, e.g. 'django.db.models.BigAutoField'.
```