### PR TITLE
Extract LDAPConnection as a separate class

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -249,7 +249,80 @@ class LDAPBackend:
         return username
 
 
-class _LDAPUser:
+class _LDAPConnectionMixIn:
+    _connection = None
+    _connection_bound = False
+
+    def __init__(self, backend):
+        self.backend = backend
+
+    @property
+    def ldap(self):
+        return self.backend.ldap
+
+    @property
+    def settings(self):
+        return self.backend.settings
+
+    @property
+    def connection(self):
+        if not self._connection_bound:
+            self._bind()
+
+        return self._get_connection()
+
+    def _bind(self):
+        """
+        Binds to the LDAP server with AUTH_LDAP_BIND_DN and
+        AUTH_LDAP_BIND_PASSWORD.
+        """
+        self._bind_as(self.settings.BIND_DN, self.settings.BIND_PASSWORD, sticky=True)
+
+    def _bind_as(self, bind_dn, bind_password, sticky=False):
+        """
+        Binds to the LDAP server with the given credentials. This does not trap
+        exceptions.
+
+        If sticky is True, then we will consider the connection to be bound for
+        the life of this object. If False, then the caller only wishes to test
+        the credentials, after which the connection will be considered unbound.
+        """
+        self._get_connection().simple_bind_s(bind_dn, bind_password)
+
+        self._connection_bound = sticky
+
+    def _get_connection(self):
+        """
+        Returns our cached LDAPObject, which may or may not be bound.
+        """
+        if self._connection is None:
+            uri = self.settings.SERVER_URI
+            if callable(uri):
+                if func_supports_parameter(uri, "request"):
+                    uri = uri(self._request)
+                else:
+                    warnings.warn(
+                        "Update AUTH_LDAP_SERVER_URI callable %s.%s to accept "
+                        "a positional `request` argument. Support for callables "
+                        "accepting no arguments will be removed in a future "
+                        "version." % (uri.__module__, uri.__name__),
+                        DeprecationWarning,
+                    )
+                    uri = uri()
+
+            self._connection = self.backend.ldap.initialize(uri, bytes_mode=False)
+
+            for opt, value in self.settings.CONNECTION_OPTIONS.items():
+                self._connection.set_option(opt, value)
+
+            if self.settings.START_TLS:
+                logger.debug("Initiating TLS")
+                self._connection.start_tls_s()
+
+        return self._connection
+
+
+class _LDAPUser(_LDAPConnectionMixIn):
     """
     Represents an LDAP user and ultimately fields all requests that the
     backend receives. This class exists for two reasons. First, it's
@@ -271,8 +344,6 @@ class _LDAPUser:
     _user_attrs = None
     _groups = None
     _group_permissions = None
-    _connection = None
-    _connection_bound = False
 
     #
     # Initialization
@@ -284,7 +355,8 @@ class _LDAPUser:
         authenticated User object. If a user is given, the username will be
         ignored.
         """
-        self.backend = backend
+        super().__init__(backend)
+
         self._username = username
         self._request = request
 
@@ -329,14 +401,6 @@ class _LDAPUser:
 
         user.ldap_user = self
         user.ldap_username = self._username
-
-    @property
-    def ldap(self):
-        return self.backend.ldap
-
-    @property
-    def settings(self):
-        return self.backend.settings
 
     #
     # Entry points
@@ -461,13 +525,6 @@ class _LDAPUser:
     @property
     def group_names(self):
         return self._get_groups().get_group_names()
-
-    @property
-    def connection(self):
-        if not self._connection_bound:
-            self._bind()
-
-        return self._get_connection()
 
     #
     # Authentication
@@ -812,60 +869,6 @@ class _LDAPUser:
             self._groups = _LDAPUserGroups(self)
 
         return self._groups
-
-    #
-    # LDAP connection
-    #
-
-    def _bind(self):
-        """
-        Binds to the LDAP server with AUTH_LDAP_BIND_DN and
-        AUTH_LDAP_BIND_PASSWORD.
-        """
-        self._bind_as(self.settings.BIND_DN, self.settings.BIND_PASSWORD, sticky=True)
-
-    def _bind_as(self, bind_dn, bind_password, sticky=False):
-        """
-        Binds to the LDAP server with the given credentials. This does not trap
-        exceptions.
-
-        If sticky is True, then we will consider the connection to be bound for
-        the life of this object. If False, then the caller only wishes to test
-        the credentials, after which the connection will be considered unbound.
-        """
-        self._get_connection().simple_bind_s(bind_dn, bind_password)
-
-        self._connection_bound = sticky
-
-    def _get_connection(self):
-        """
-        Returns our cached LDAPObject, which may or may not be bound.
-        """
-        if self._connection is None:
-            uri = self.settings.SERVER_URI
-            if callable(uri):
-                if func_supports_parameter(uri, "request"):
-                    uri = uri(self._request)
-                else:
-                    warnings.warn(
-                        "Update AUTH_LDAP_SERVER_URI callable %s.%s to accept "
-                        "a positional `request` argument. Support for callables "
-                        "accepting no arguments will be removed in a future "
-                        "version." % (uri.__module__, uri.__name__),
-                        DeprecationWarning,
-                    )
-                    uri = uri()
-
-            self._connection = self.backend.ldap.initialize(uri, bytes_mode=False)
-
-            for opt, value in self.settings.CONNECTION_OPTIONS.items():
-                self._connection.set_option(opt, value)
-
-            if self.settings.START_TLS:
-                logger.debug("Initiating TLS")
-                self._connection.start_tls_s()
-
-        return self._connection
 
 
 class _LDAPUserGroups:


### PR DESCRIPTION
This is for the needs of https://github.com/django-auth-ldap/django-auth-ldap/pull/150#issuecomment-839819162

The first step of the refactoring is the first commit from #150 and in the second commit we refactor further to have `LDAPConnection` as a separate class, as suggested in the linked comment. 

`_LDAPUser` gets some one-liner methods that just reference `self._connection`:
```
    def _bind(self):
        self._connection._bind()

    def _bind_as(self, bind_dn, bind_password, sticky=False):
        return self._connection._bind_as(bind_dn, bind_password, sticky)

    def _get_connection(self):
        return self._connection._get_connection()

    @property
    def connection(self):
        return self._connection.connection
```
This is in order to avoid changing the API - we probably don't want to break code relying on this module doing things like `ldap_user.connection`.

@francoisfreitag I'm not sure if this is the kind of design you wanted for `LDAPConnection`, so I'm happy to rework or tweak this as needed to get it mergeable but might need more pointers on what you have in mind for this class.