### PR TITLE
Add setting to change the default cache used

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -57,8 +57,9 @@ import django.dispatch
 import ldap
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from django.utils.functional import cached_property
 from django.utils.inspect import func_supports_parameter
 
 from django_auth_ldap.config import (
@@ -111,6 +112,10 @@ class LDAPBackend:
         return {
             k: v for k, v in self.__dict__.items() if k not in ["_settings", "_ldap"]
         }
+
+    @cached_property
+    def cache(self):
+        return caches[getattr(self.settings, "AUTH_LDAP_CACHE", "default")]
 
     @property
     def settings(self):
@@ -514,7 +519,7 @@ class _LDAPUser:
                 cache_key = valid_cache_key(
                     "django_auth_ldap.user_dn.{}".format(self._username)
                 )
-                self._user_dn = cache.get_or_set(
+                self._user_dn = self.cache.get_or_set(
                     cache_key, self._search_for_user_dn, self.settings.CACHE_TIMEOUT
                 )
             else:
@@ -971,14 +976,14 @@ class _LDAPUserGroups:
     def _load_cached_attr(self, attr_name):
         if self.settings.CACHE_TIMEOUT > 0:
             key = self._cache_key(attr_name)
-            value = cache.get(key)
+            value = self.cache.get(key)
             setattr(self, attr_name, value)
 
     def _cache_attr(self, attr_name):
         if self.settings.CACHE_TIMEOUT > 0:
             key = self._cache_key(attr_name)
             value = getattr(self, attr_name, None)
-            cache.set(key, value, self.settings.CACHE_TIMEOUT)
+            self.cache.set(key, value, self.settings.CACHE_TIMEOUT)
 
     def _cache_key(self, attr_name):
         """

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -341,6 +341,33 @@ Values may be strings for simple group membership tests or
 cases.
 
 
+.. setting:: AUTH_LDAP_CACHE
+
+AUTH_LDAP_CACHE
+~~~~~~~~~~~~~~~
+
+Default: ``default``
+
+The Django cache framework can store and manage multiple caches, each with
+their own unique name. By default, the default cache is used. Setting this
+value tells django-auth-ldap to use a different cache than the default. It
+should match a name in the Django cache settings.
+
+.. code-block:: python
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/1'
+        },
+        'ldap-cache': {
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'LOCATION': 'unix:/tmp/memcached.sock',
+        },
+    }
+    AUTH_LDAP_CACHE = 'ldap-cache'
+
+
 .. setting:: AUTH_LDAP_USER_SEARCH
 
 AUTH_LDAP_USER_SEARCH


### PR DESCRIPTION
It is handy to be able to flush the ldap cache without flushing the entire default django cache. That can reset non-token based logins and all kinds of data you may or may not want. Being able to configure it to use it's own independent cache within the Django caching framework is reallllly handy!

I had previously submitted this before but the tree was really out of date so it was easier to incorporate the suggested changes in a new branch and resubmit.