### PR TITLE
Drop deprecated AUTH_LDAP_SERVER_URI and AUTH_LDAP_CACHE_GROUPS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+- Dropped deprecated setting ``AUTH_LDAP_CACHE_GROUPS``.
+- Callables passed to ``AUTH_LDAP_SERVER_URI`` must now take a ``request`` positional argument.
 - Dropped support for Django 3.0.
 
 2.4.0 - 2021-04-06

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -83,14 +83,6 @@ The value determines the amount of time, in seconds, a user's group memberships
 and distinguished name are cached. The value ``0``, the default, disables
 caching entirely.
 
-.. versionchanged:: 1.6.0
-
-    Previously caching was controlled by the settings `AUTH_LDAP_CACHE_GROUPS`
-    and `AUTH_LDAP_GROUP_CACHE_TIMEOUT`. If `AUTH_LDAP_CACHE_GROUPS` is set,
-    the `AUTH_LDAP_CACHE_TIMEOUT` value is derievd from these deprecated
-    settings.
-
-
 .. setting:: AUTH_LDAP_CONNECTION_OPTIONS
 
 AUTH_LDAP_CONNECTION_OPTIONS


### PR DESCRIPTION
These settings have been deprecated for 3 years. Their tests are failing
on Python 3.10, because they expect a single deprecation warning, but
get the following deprecation warnings from Django:

django/utils/asyncio.py:19: DeprecationWarning: There is no current event loop
  event_loop = asyncio.get_event_loop()

Instead of fixing the tests, drop the deprecated code.

Closes #257 