### PR TITLE
Drop deprecated setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "wheel",
     "setuptools_scm[toml]>=3.4",
 ]
+build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools_scm]
 write_to = "django_auth_ldap/version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     django31
     django32
     djangomain
+isolated_build = true
 
 [testenv]
 commands = {envpython} -Wa -b -m django test --settings tests.settings
@@ -33,6 +34,7 @@ commands = isort --check --diff .
 skip_install = true
 
 [testenv:docs]
+isolated_build = true
 deps =
     readme_renderer
     sphinx
@@ -42,9 +44,11 @@ whitelist_externals = make
 
 [testenv:packaging]
 deps =
+    build
+    setuptools
     twine
     wheel
 skip_install = true
 commands =
-    python setup.py sdist bdist_wheel
+    python -m build
     twine check dist/*


### PR DESCRIPTION
Prefer the declarative syntax of setup.cfg. To package the project:

```
pip install build
python -m build
```

https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html