### PR TITLE
Adjust tests to python-ldap==3.4.0

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -132,15 +132,15 @@ class LDAPTest(TestCase):
         cls.server = slapdtest.SlapdObject()
         cls.server.suffix = "o=test"
         cls.server.openldap_schema_files = [
-            "core.schema",
-            "cosine.schema",
-            "inetorgperson.schema",
-            "nis.schema",
+            "core.ldif",
+            "cosine.ldif",
+            "inetorgperson.ldif",
+            "nis.ldif",
         ]
         cls.server.start()
         with open(os.path.join(here, "tests.ldif")) as fp:
             ldif = fp.read()
-        cls.server.ldapadd(ldif)
+        cls.server.slapadd(ldif)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Before https://github.com/python-ldap/python-ldap/pull/382/, the schema
files were included in slapd.conf, so the additional schema files were
listed.

The release python-ldap==3.4.0 is the first with
https://github.com/python-ldap/python-ldap/pull/382/, which migrates to
the modern configuration for SlapdObject. The LDIF files should now be
used to configure slapd.