### PR TITLE
Docs: Use newer locations for python-ldap and tox in intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,6 +195,6 @@ intersphinx_mapping = {
         "https://docs.djangoproject.com/en/stable/",
         "https://docs.djangoproject.com/en/stable/_objects/",
     ),
-    "pythonldap": ("https://python-ldap.readthedocs.io/en/latest/", None),
-    "tox": ("https://tox.readthedocs.io/en/latest/", None),
+    "pythonldap": ("https://www.python-ldap.org/en/latest/", None),
+    "tox": ("https://tox.wiki/en/latest/", None),
 }


### PR DESCRIPTION
Avoids redirects.