### PR TITLE
Add debug logging before bind or search_as

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -830,6 +830,7 @@ class _LDAPUser:
         the life of this object. If False, then the caller only wishes to test
         the credentials, after which the connection will be considered unbound.
         """
+        logger.debug(f"Attempting bind as {bind_dn}")
         self._get_connection().simple_bind_s(bind_dn, bind_password)
 
         self._connection_bound = sticky

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -830,7 +830,7 @@ class _LDAPUser:
         the life of this object. If False, then the caller only wishes to test
         the credentials, after which the connection will be considered unbound.
         """
-        logger.debug(f"Binding as {bind_dn}")
+        logger.debug("Binding as %s", bind_dn)
         self._get_connection().simple_bind_s(bind_dn, bind_password)
 
         self._connection_bound = sticky

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -830,7 +830,7 @@ class _LDAPUser:
         the life of this object. If False, then the caller only wishes to test
         the credentials, after which the connection will be considered unbound.
         """
-        logger.debug(f"Attempting bind as {bind_dn}")
+        logger.debug(f"Binding as {bind_dn}")
         self._get_connection().simple_bind_s(bind_dn, bind_password)
 
         self._connection_bound = sticky

--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -144,7 +144,7 @@ class LDAPSearch:
 
         try:
             filterstr = self.filterstr % filterargs
-            logger.error(
+            logger.debug(
                 "Invoking search_s('{}', {}, '{}')".format(
                     self.base_dn, self.scope, filterstr
                 )

--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -145,9 +145,7 @@ class LDAPSearch:
         try:
             filterstr = self.filterstr % filterargs
             logger.debug(
-                "Invoking search_s('{}', {}, '{}')".format(
-                    self.base_dn, self.scope, filterstr
-                )
+                "Invoking search_s('%s', %s, '%s')", self.base_dn, self.scope, filterstr
             )
             results = connection.search_s(
                 self.base_dn, self.scope, filterstr, self.attrlist

--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -144,6 +144,11 @@ class LDAPSearch:
 
         try:
             filterstr = self.filterstr % filterargs
+            logger.error(
+                "Invoking search_s('{}', {}, '{}')".format(
+                    self.base_dn, self.scope, filterstr
+                )
+            )
             results = connection.search_s(
                 self.base_dn, self.scope, filterstr, self.attrlist
             )


### PR DESCRIPTION
Log at debug level before binding or searching. This serves 2 purposes:
1. It includes details on success that are not otherwise logged except on failure.
2. When tailing the log, and the server is not responding, indicates what operation is in progress.