### PR TITLE
Add support for extend user model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,13 @@ settings and arguments are included for completeness.
         'first_name': 'givenName',
         'last_name': 'sn',
         'email': 'mail',
+        # The name of the nested dictionary must match the name 
+        # of the extended model's reverse relation.
+        'ldap': {
+            'title': 'title',
+            'cn': 'cn',
+            'dn': 'distinguishedName',
+        }
     }
 
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {


### PR DESCRIPTION
I suggest to enable rework to support [extended models](https://docs.djangoproject.com/en/4.0/topics/auth/customizing/#extending-the-existing-user-model). Now the extended model (class Profile from example) remains empty if we try to write some ldap attribute to it.

_PS (although this does not apply to ldap, I felt it necessary to mention it here)
Behind the scenes was the need to register a signal to save the extended model in the database:_
```csharp
@receiver(post_save, sender=User)
def save_user_profile(sender, instance, **kwargs):
    if hasattr(instance, 'profile'):
        instance.profile.save()
```