### PR TITLE
Drop support for Django 2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,18 +17,12 @@ jobs:
           - 3.9
           - '3.10'
         tox-environment:
-          - django22
           - django32
           - django40
+          - djangomain
         include:
           - python-version: 3.7
-            tox-environment: django22
-          - python-version: 3.7
             tox-environment: django32
-          - python-version: 3.9
-            tox-environment: djangomain
-          - python-version: '3.10'
-            tox-environment: djangomain
 
     env:
       TOXENV: ${{ matrix.tox-environment }}

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,6 @@ groups, and permissions.
 * Repository: https://github.com/django-auth-ldap/django-auth-ldap
 * License: BSD 2-Clause
 
-This version is supported on Python 3.7+; and Django 2.2+. It requires
-`python-ldap`_ >= 3.1.
-
 .. _`python-ldap`: https://pypi.org/project/python-ldap/
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Intended Audience :: Developers
@@ -36,7 +35,7 @@ project_urls =
 python_requires = >=3.7
 packages = django_auth_ldap
 install_requires =
-    Django>=2.2
+    Django>=3.2
     python-ldap>=3.1
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     flake8
     isort
     docs
-    django22
     django32
     django40
     djangomain
@@ -13,7 +12,6 @@ isolated_build = true
 [testenv]
 commands = {envpython} -Wa -b -m django test --settings tests.settings
 deps =
-    django22: Django~=2.2.0
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Removed mention of supported versions in the README, can use the PyPI
metadata declared in setup.cfg.