### PR TITLE
Add changelog URL to PyPI package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ project_urls =
     Documentation = https://django-auth-ldap.readthedocs.io/
     Source = https://github.com/django-auth-ldap/django-auth-ldap
     Tracker = https://github.com/django-auth-ldap/django-auth-ldap/issues
+    Changelog = https://django-auth-ldap.readthedocs.io/en/latest/changes.html
 
 [options]
 python_requires = >=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ project_urls =
     Documentation = https://django-auth-ldap.readthedocs.io/
     Source = https://github.com/django-auth-ldap/django-auth-ldap
     Tracker = https://github.com/django-auth-ldap/django-auth-ldap/issues
-    Changelog = https://django-auth-ldap.readthedocs.io/en/latest/changes.html
+    Changelog = https://github.com/django-auth-ldap/django-auth-ldap/releases/
 
 [options]
 python_requires = >=3.7


### PR DESCRIPTION
This changelog link will be visible on the package's PyPI page.

Also tools like Renovate bot use this metadata to provide quicker access to the changelog for a dependency update.
