### PR TITLE
Remove package= from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ project_urls =
 
 [options]
 python_requires = >=3.7
-packages = django_auth_ldap
 install_requires =
     Django>=3.2
     python-ldap>=3.1


### PR DESCRIPTION
The package is unnecessary, setuptools_scm knows what files to package
from source control.