### PR TITLE
Implement rate-limiting of user saves to spare the database

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -46,6 +46,7 @@ import pprint
 import re
 import warnings
 from functools import reduce
+from datetime import datetime, timedelta as delta_sec
 
 import django.conf
 import django.dispatch
@@ -613,7 +614,7 @@ class _LDAPUser:
         self._user.ldap_user = self
         self._user.ldap_username = self._username
 
-        should_populate = force_populate or self.settings.ALWAYS_UPDATE_USER or built
+        should_populate = force_populate or self._always_update_user_throttled or built
 
         if built:
             if self.settings.NO_NEW_USERS:
@@ -641,6 +642,23 @@ class _LDAPUser:
         if self.settings.MIRROR_GROUPS or self.settings.MIRROR_GROUPS_EXCEPT:
             self._normalize_mirror_settings()
             self._mirror_groups()
+
+    @property
+    def _always_update_user_throttled(self):
+        """
+        Returns self.settings.ALWAYS_UPDATE_USER if ALWAYS_UPDATE_USER_THROTTLE_SEC == 0.
+        Otherwise, returns whether the required interval since last_login has elapsed.
+        """
+        if self.settings.ALWAYS_UPDATE_USER_THROTTLE_SEC > 0 and self.settings.ALWAYS_UPDATE_USER:
+            last_login = self._user.last_login
+            tz = last_login.tzinfo
+            throttle_interval_end = last_login + throttle_interval
+            if datetime.now(tz=tz) >= throttle_interval_end:
+                return True
+            else:
+                logger.info(f"Throttling user updates until {throttle_interval_end} due to ALWAYS_UPDATE_USER_THROTTLE_SEC")
+        else:
+            return self.settings.ALWAYS_UPDATE_USER
 
     def _populate_user(self):
         """

--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -53,6 +53,7 @@ class LDAPSettings:
 
     defaults = {
         "ALWAYS_UPDATE_USER": True,
+        "ALWAYS_UPDATE_USER_THROTTLE_SEC": 0,
         "AUTHORIZE_ALL_USERS": False,
         "BIND_AS_AUTHENTICATING_USER": False,
         "REFRESH_DN_ON_BIND": False,


### PR DESCRIPTION
Attempting to resolve Issue #354 .

This PR allows an application admin to set an optional interval in seconds within which `_LDAPUser._get_or_create_user()` will not call `self._user.save()` for the same user again.

The intended use is to set `AUTH_LDAP_ALWAYS_UPDATE_USER_THROTTLE_SEC` to small single-digit values, e.g. `3`, thereby capping ldap-auth-related SQL `UPDATE "auth_user"...` commands to no more than 1 every 3 seconds (down from something like 20 every 3 seconds like I recently saw).