### PR TITLE
feature: adding support custom username field

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -141,7 +141,7 @@ class LDAPBackend:
 
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username is None:
-            return None
+            username = kwargs.get(self.get_user_model().USERNAME_FIELD)
 
         if password or self.settings.PERMIT_EMPTY_PASSWORD:
             ldap_user = _LDAPUser(self, username=username.strip(), request=request)

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -140,8 +140,9 @@ class LDAPBackend:
     #
 
     def authenticate(self, request, username=None, password=None, **kwargs):
+        username = kwargs.get(self.get_user_model().USERNAME_FIELD, username)
         if username is None:
-            username = kwargs.get(self.get_user_model().USERNAME_FIELD)
+            return None
 
         if password or self.settings.PERMIT_EMPTY_PASSWORD:
             ldap_user = _LDAPUser(self, username=username.strip(), request=request)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -275,6 +275,17 @@ class LDAPTest(TestCase):
         user = deepcopy(user)
 
     @_override_settings(AUTH_USER_MODEL="tests.TestUser")
+    def test_auth_custom_field(self):
+        self._init_settings(
+            USER_DN_TEMPLATE="cn=%(user)s,ou=people,o=test",
+            USER_ATTR_MAP={"identifier": "cn"},
+        )
+        charlie = TestUser.objects.create(identifier="charlie_cooper", uid_number=1004)
+        user = authenticate(identifier="charlie_cooper", password="password")
+        self.assertIsInstance(user, TestUser)
+        self.assertEqual(user.identifier, charlie.identifier)
+
+    @_override_settings(AUTH_USER_MODEL="tests.TestUser")
     def test_auth_custom_user(self):
         self._init_settings(
             USER_DN_TEMPLATE="uid=%(user)s,ou=people,o=test",


### PR DESCRIPTION
I faced a problem when implementing this package in my project. The administrator panel worked perfectly when authorizing, but for example package simplejwt (drf) sent data based on a custom field of the user.

Link: https://github.com/jazzband/djangorestframework-simplejwt/blob/c791e987332ed5e22a86428160d6372b1d85ffae/rest_framework_simplejwt/serializers.py#L41

In this pull-request we added a check for the "username" field

Link to Django ModelBackend: https://github.com/django/django/blob/ae10146793dca0e0594c7acdee20ca3810983f39/django/contrib/auth/backends.py#L38