### PR TITLE
Use ruff instead of black, flake8 and isort

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,20 +6,8 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.tox-environment }}
+    name: check
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        tox-environment:
-          - black
-          - flake8
-          - isort
-
-    env:
-      TOXENV: ${{ matrix.tox-environment }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -30,4 +18,4 @@ jobs:
         run: python -m pip install tox
 
       - name: Run
-        run: tox
+        run: tox -e ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,15 @@ Source = "https://github.com/django-auth-ldap/django-auth-ldap"
 Tracker = "https://github.com/django-auth-ldap/django-auth-ldap/issues"
 Changelog = "https://github.com/django-auth-ldap/django-auth-ldap/releases/"
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+# See prefixes in https://beta.ruff.rs/docs/rules/
+select = [
+    "F",   # pyflakes
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "I",   # isort
+    "C4",  # flake8-comprehension
+]
 
 [build-system]
 requires = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-    black
-    flake8
-    isort
+    ruff
     docs
     django32
     django42
@@ -18,19 +16,9 @@ deps =
     django50: Django>=5.0,<5.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
-[testenv:black]
-deps = black
-commands = black --check --diff .
-skip_install = true
-
-[testenv:flake8]
-deps = flake8
-commands = flake8
-skip_install = true
-
-[testenv:isort]
-deps = isort>=5.0.1
-commands = isort --check --diff .
+[testenv:ruff]
+deps = ruff
+commands = ruff check .
 skip_install = true
 
 [testenv:docs]


### PR DESCRIPTION
Simpler, fully configured from pyproject.toml, and faster.