### PR TITLE
Use pip cache (and specify Python version for workflows)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+          cache: pip
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+          cache: pip
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: 3.x
 
       - name: Install dependencies
         run: pip install --user build setuptools twine wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+          cache: pip
 
       - name: Install dependencies
         run: pip install --user build setuptools twine wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install dependencies
         run: python -m pip install tox-gh

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ skip_install = true
 isolated_build = true
 deps =
     readme_renderer
+    setuptools>=65.0
     sphinx
 commands =
     make -C docs html


### PR DESCRIPTION
Not specifying causes the system python version to be used, and preventing the cache from working.