### PR TITLE
Propagate LDAP errors instead of silently ignoring, send more ldap_error signals

### DIFF
--- a/django_auth_ldap/config.py
+++ b/django_auth_ldap/config.py
@@ -197,23 +197,13 @@ class LDAPSearch:
         if escape:
             filterargs = self._escape_filterargs(filterargs)
 
-        try:
-            filterstr = self.filterstr % filterargs
-            logger.debug(
-                "Invoking search_s('%s', %s, '%s')", self.base_dn, self.scope, filterstr
-            )
-            results = connection.search_s(
-                self.base_dn, self.scope, filterstr, self.attrlist
-            )
-        except ldap.LDAPError as e:
-            results = []
-            logger.error(
-                "search_s('%s', %s, '%s') raised %s",
-                self.base_dn,
-                self.scope,
-                filterstr,
-                pprint.pformat(e),
-            )
+        filterstr = self.filterstr % filterargs
+        logger.debug(
+            "Invoking search_s('%s', %s, '%s')", self.base_dn, self.scope, filterstr
+        )
+        results = connection.search_s(
+            self.base_dn, self.scope, filterstr, self.attrlist
+        )
 
         return self._process_results(results)
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -577,20 +577,23 @@ Backend
 
 .. data:: ldap_error
 
-
     This is a Django signal that is sent when we receive an
     :exc:`ldap.LDAPError` exception. The signal has four keyword arguments:
 
     - ``context``: one of ``'authenticate'``, ``'get_group_permissions'``, or
-      ``'populate_user'``, indicating which API was being called when the
-      exception was caught.
-    - ``user``: the Django user being processed (if available).
+      ``'populate_user'``, ``'search_for_user_dn'`` or ``'mirror_groups'``,
+      indicating which API was being called when the exception was caught.
+    - ``user``: the Django user being processed (if available) or ``None``.
     - ``request``: the Django request object associated with the
-      authentication attempt (if available).
+      authentication attempt (if available) or ``None``.
     - ``exception``: the :exc:`~ldap.LDAPError` object itself.
 
     The sender is the :class:`~django_auth_ldap.backend.LDAPBackend` class (or
     subclass).
+
+    By default, LDAP errors are be handled by ``django_auth_ldap`` by failing
+    the authentication. If instead you wish to propagate the error to up
+    application code, then raise an exception from the signal handler.
 
 .. class:: LDAPBackend
 


### PR DESCRIPTION
Before I add tests and put more effort in this PR, I would like some indication that I'm on the right track. Please let me know, what you think.

Fixes #378.

* LDAPError exceptions are now propagated from the `LDAPSearch.execute()` method, which is used internally in many code paths. It's now possible to distinguish errors from empty results.
* In particular `NestedMemberDNGroupType` no longer returns partial results when faced with errors -- fixes #378.
* When `MIRROR_GROUPS` or `MIRROR_GROUPS_EXCEPT` is enabled, then an error during group mirroring will fail authentication. Previously it could mirror a partial set of groups or remove all groups.
* The `ldap_error` Django signal is now sent for more situations -- previously it only reported errors from authentication, but nothing else.

----

* We could enable the new 'error propagation' logic unconditionally in newer `django-auth-ldap` versions.
* To ease migration pains, we could enable new logic by default, but create a setting to restore previous "ignore" behavior. Though if some environment frequently experiences errors, the admins should be made aware of it.
* I could also make error propagation an opt-in feature, and restore old behavior by default.
