### PR TITLE
Stop testing Python 3.10 and 3.11 against django main

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ isolated_build = true
 [gh]
 python =
     3.9 = django42
-    3.10 = django{42,50,51,main}
-    3.11 = django{42,50,51,main}
+    3.10 = django{42,50,51}
+    3.11 = django{42,50,51}
     3.12 = django{42,50,51,main}
     3.13 = django{42,50,51,main}
 


### PR DESCRIPTION
Django dropped support for these Python versions on main.