### PR TITLE
set log level to info when creating an user

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -642,7 +642,7 @@ class _LDAPUser:
                     "user does not satisfy AUTH_LDAP_NO_NEW_USERS"
                 )
 
-            logger.debug("Creating Django user %s", username)
+            logger.info("Creating Django user %s", username)
             self._user.set_unusable_password()
             save_user = True
 


### PR DESCRIPTION
This way, admins have a way to log users creation while not logging LDAP traffic.