### PR TITLE
Align CI with python-ldap

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   build:
     name: Documentation
-    runs-on: ubuntu-latest
+    # https://github.com/python-ldap/python-ldap/blob/main/.github/workflows/ci.yml
+    runs-on: ubuntu-22.04
 
     env:
       TOXENV: docs
@@ -15,11 +16,9 @@ jobs:
     steps:
       - name: Install LDAP libs
         run: |
-          sudo apt-get update
-          # https://www.python-ldap.org/en/latest/installing.html#debian
-          sudo apt-get install slapd ldap-utils libldap2-dev libsasl2-dev
-          # https://github.com/python-ldap/python-ldap/issues/370
-          sudo apt-get install apparmor-utils
+          sudo apt update
+          # https://github.com/python-ldap/python-ldap/blob/main/.github/workflows/ci.yml
+          sudo apt install -y ldap-utils slapd enchant-2 libldap2-dev libsasl2-dev apparmor-utils
           sudo aa-disable /usr/sbin/slapd
 
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   test:
     name: Python ${{ matrix.python-version }} / ${{ matrix.tox-environment }}
-    runs-on: ubuntu-latest
+    # https://github.com/python-ldap/python-ldap/blob/main/.github/workflows/ci.yml
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -24,10 +25,8 @@ jobs:
       - name: Install LDAP libs
         run: |
           sudo apt-get update
-          # https://www.python-ldap.org/en/latest/installing.html#debian
-          sudo apt-get install slapd ldap-utils libldap2-dev libsasl2-dev
-          # https://github.com/python-ldap/python-ldap/issues/370
-          sudo apt-get install apparmor-utils
+          # https://github.com/python-ldap/python-ldap/blob/main/.github/workflows/ci.yml
+          sudo apt install -y ldap-utils slapd enchant-2 libldap2-dev libsasl2-dev apparmor-utils
           sudo aa-disable /usr/sbin/slapd
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 24.04 does not support the AppArmor trick used on 22.04, and there is no documented workaround. Follow the configuration from python-ldap.