### PR TITLE
Increase log level to info when creating/populating a user

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -642,12 +642,12 @@ class _LDAPUser:
                     "user does not satisfy AUTH_LDAP_NO_NEW_USERS"
                 )
 
-            logger.debug("Creating Django user %s", username)
+            logger.info("Creating Django user %s", username)
             self._user.set_unusable_password()
             save_user = True
 
         if should_populate:
-            logger.debug("Populating Django user %s", username)
+            logger.info("Populating Django user %s", username)
             self._populate_user()
             save_user = True
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -582,8 +582,8 @@ class LDAPTest(TestCase):
             [(log.levelname, log.msg, log.args) for log in logs.records],
             [
                 ("DEBUG", "Binding as %s", (dn,)),
-                ("DEBUG", "Creating Django user %s", ("alice",)),
-                ("DEBUG", "Populating Django user %s", ("alice",)),
+                ("INFO", "Creating Django user %s", ("alice",)),
+                ("INFO", "Populating Django user %s", ("alice",)),
                 ("DEBUG", "Binding as %s", ("",)),
                 (
                     "DEBUG",


### PR DESCRIPTION
This way, admins have a way to log users creation and update while not
logging LDAP traffic.
