### PR TITLE
Fix documentation build on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,5 @@ build:
 python:
   install:
     - requirements: docs/requirements.txt
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/